### PR TITLE
Fix SonarQube coverage reporting for sentinel-ai-examples

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,8 +93,8 @@
 
         <!-- All other modules above this -->
         <module>sentinel-ai-bom</module>
-        <module>sentinel-ai-reporting</module>
         <module>sentinel-ai-examples</module>
+        <module>sentinel-ai-reporting</module>
     </modules>
 
     <properties>

--- a/sentinel-ai-reporting/pom.xml
+++ b/sentinel-ai-reporting/pom.xml
@@ -76,6 +76,13 @@
             <artifactId>sentinel-ai-storage-es</artifactId>
             <version>${project.version}</version>
         </dependency>
+
+        <!-- examples -->
+        <dependency>
+            <groupId>com.phonepe.sentinel-ai</groupId>
+            <artifactId>sentinel-ai-examples</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
- Add sentinel-ai-examples as a dependency to sentinel-ai-reporting so its JaCoCo .exec data is included in the aggregate coverage report
- Move sentinel-ai-examples before sentinel-ai-reporting in the root module list so tests run before the aggregate report is generated