### PR TITLE
[COVERAGE] Refactor for testability and add direct tests to improve n…

### DIFF
--- a/sentinel-ai-examples/src/main/java/com/phonepe/sentinelai/examples/texttosql/cli/TextToSqlCLI.java
+++ b/sentinel-ai-examples/src/main/java/com/phonepe/sentinelai/examples/texttosql/cli/TextToSqlCLI.java
@@ -249,7 +249,7 @@ public class TextToSqlCLI implements Callable<Integer> {
      * Resolves the effective session ID, generating a random UUID when the caller did not supply
      * one.
      */
-    private static String resolveSessionId(String sessionId) {
+    static String resolveSessionId(String sessionId) {
         final String resolved =
                 (sessionId == null || sessionId.isBlank())
                         ? UUID.randomUUID().toString()
@@ -264,7 +264,7 @@ public class TextToSqlCLI implements Callable<Integer> {
      * @return absolute path to the database file
      */
     @SneakyThrows
-    private static Path initializeDatabase(CliConfig config) {
+    static Path initializeDatabase(CliConfig config) {
         final Path dbPath = Paths.get(config.getDatabase().getPath()).toAbsolutePath();
         log.info("Initialising database at {}", dbPath);
         DatabaseInitializer.ensureInitialised(dbPath);
@@ -278,7 +278,7 @@ public class TextToSqlCLI implements Callable<Integer> {
      * @return the base URL of the running server (e.g. {@code http://localhost:12345})
      */
     @SneakyThrows
-    private static String startRestServer(Path dbPath, ObjectMapper mapper) {
+    static String startRestServer(Path dbPath, ObjectMapper mapper) {
         log.info("Starting embedded SQLite REST server for database {}", dbPath);
         final int port = SqliteRestServer.findFreePort();
         final String baseUrl = SqliteRestServer.startEmbedded(dbPath.toString(), port, mapper);
@@ -291,7 +291,7 @@ public class TextToSqlCLI implements Callable<Integer> {
      * interceptors that inject the OpenAI authorization header on every outgoing request.
      */
     @SneakyThrows
-    private static OkHttpClientAdapter buildTrustedHttpClient(CliConfig config) {
+    static OkHttpClientAdapter buildTrustedHttpClient(CliConfig config) {
         log.info("Building HTTP client");
 
         final String apiKey = config.getOpenai().getApiKey();
@@ -332,8 +332,7 @@ public class TextToSqlCLI implements Callable<Integer> {
         return new OkHttpClientAdapter(httpClient);
     }
 
-    /** Constructs the {@link SimpleOpenAIModel} wired to the configured model name and base URL. */
-    private static SimpleOpenAIModel<?> buildOpenAIModel(
+    static SimpleOpenAIModel<?> buildOpenAIModel(
             CliConfig config, OkHttpClientAdapter clientAdapter, ObjectMapper mapper) {
         log.info(
                 "Building OpenAI model [name={}, baseUrl={}]",
@@ -354,7 +353,7 @@ public class TextToSqlCLI implements Callable<Integer> {
      * Creates the {@link AgentSetup} that controls model behaviour (temperature, max tokens, output
      * mode).
      */
-    private static AgentSetup buildAgentSetup(
+    static AgentSetup buildAgentSetup(
             CliConfig config, SimpleOpenAIModel<?> model, ObjectMapper mapper) {
         log.info(
                 "Configuring agent setup [temperature={}, maxTokens={}, streaming={}]",
@@ -379,7 +378,7 @@ public class TextToSqlCLI implements Callable<Integer> {
      * temporary directory when no explicit skills directory was supplied.
      */
     @SneakyThrows
-    private AgentSkillsExtension<String, SqlQueryResult, TextToSqlAgent> buildSkillsExtension() {
+    AgentSkillsExtension<String, SqlQueryResult, TextToSqlAgent> buildSkillsExtension() {
         final String resolvedSkillsDir = resolveSkillsDir();
         log.info("Building skills extension from directory: {}", resolvedSkillsDir);
         return AgentSkillsExtension.<String, SqlQueryResult, TextToSqlAgent>withMultipleSkills()
@@ -389,7 +388,7 @@ public class TextToSqlCLI implements Callable<Integer> {
     }
 
     /** Instantiates the {@link TextToSqlAgent} with the provided setup and skills extension. */
-    private static TextToSqlAgent buildAgent(
+    static TextToSqlAgent buildAgent(
             AgentSetup agentSetup,
             AgentSkillsExtension<String, SqlQueryResult, TextToSqlAgent> skillsExtension) {
         log.info("Building Text-to-SQL agent");
@@ -412,7 +411,7 @@ public class TextToSqlCLI implements Callable<Integer> {
      * agent can either ask a free-form question ({@code ask_user_question}) or present a numbered
      * list of choices ({@code ask_user_to_choose}).
      */
-    private static void registerAskUserTool(TextToSqlAgent agent) {
+    static void registerAskUserTool(TextToSqlAgent agent) {
         log.info("Registering ask-user tool");
         agent.registerToolbox(new AskUserTool());
         log.info("Ask-user tool registered successfully");
@@ -426,7 +425,7 @@ public class TextToSqlCLI implements Callable<Integer> {
      * under {@code {dataDir}/lucene-schema-index/}, building the index on first run.
      */
     @SneakyThrows
-    private static void registerLocalTools(TextToSqlAgent agent, Path dbPath) {
+    static void registerLocalTools(TextToSqlAgent agent, Path dbPath) {
         final Path dataDir = dbPath.getParent();
         log.info("Registering local SQL tools for database: {} (dataDir: {})", dbPath, dataDir);
         agent.registerTools(ToolUtils.readTools(new LocalTools(dbPath.toString(), dataDir)));
@@ -438,7 +437,7 @@ public class TextToSqlCLI implements Callable<Integer> {
      * embedded Dropwizard server.
      */
     @SneakyThrows
-    private static void registerHttpToolbox(
+    static void registerHttpToolbox(
             TextToSqlAgent agent, String baseUrl, ObjectMapper mapper) {
         log.info("Registering HTTP toolbox at base URL: {}", baseUrl);
         final var toolSource = new InMemoryHttpToolSource();
@@ -465,7 +464,7 @@ public class TextToSqlCLI implements Callable<Integer> {
      * <p>The subprocess is started using the current JVM executable and the running classpath, so
      * no separate JAR distribution is required.
      */
-    private static void registerMcpToolbox(TextToSqlAgent agent, Path dbPath, ObjectMapper mapper) {
+    static void registerMcpToolbox(TextToSqlAgent agent, Path dbPath, ObjectMapper mapper) {
         final String javaCmd = ProcessHandle.current().info().command().orElse("java");
         final String classpath = System.getProperty("java.class.path");
         log.info("Registering MCP toolbox [javaCmd={}, dbPath={}]", javaCmd, dbPath);
@@ -502,7 +501,7 @@ public class TextToSqlCLI implements Callable<Integer> {
      * ready before registering the toolbox.
      */
     @SneakyThrows
-    private static void registerMcpToolboxSse(
+    static void registerMcpToolboxSse(
             TextToSqlAgent agent, Path dbPath, ObjectMapper mapper, int port) {
         final String javaCmd = ProcessHandle.current().info().command().orElse("java");
         final String classpath = System.getProperty("java.class.path");
@@ -553,7 +552,7 @@ public class TextToSqlCLI implements Callable<Integer> {
      * @throws IllegalStateException if the port does not become reachable within {@code timeoutMs}
      */
     @SneakyThrows
-    private static void waitForMcpSseServer(String host, int port, long timeoutMs)
+    static void waitForMcpSseServer(String host, int port, long timeoutMs)
             throws InterruptedException {
         final long deadline = System.currentTimeMillis() + timeoutMs;
         while (System.currentTimeMillis() < deadline) {
@@ -711,7 +710,7 @@ public class TextToSqlCLI implements Callable<Integer> {
     // -------------------------------------------------------------------------
 
     @SneakyThrows
-    private static CliConfig loadConfig(String configPath) {
+    static CliConfig loadConfig(String configPath) {
         final Path path = Paths.get(configPath);
         if (!Files.exists(path)) {
             System.err.println("Config file not found: " + path.toAbsolutePath());
@@ -726,7 +725,7 @@ public class TextToSqlCLI implements Callable<Integer> {
         return yamlMapper.readValue(path.toFile(), CliConfig.class);
     }
 
-    private static void validateConfig(CliConfig config) {
+    static void validateConfig(CliConfig config) {
         if (config.getOpenai().getApiKey() == null || config.getOpenai().getApiKey().isBlank()) {
             System.err.println("Error: openai.apiKey must be set in the credentials file.");
             System.exit(1);
@@ -741,7 +740,7 @@ public class TextToSqlCLI implements Callable<Integer> {
      * can discover it on the filesystem.
      */
     @SneakyThrows
-    private String resolveSkillsDir() {
+    String resolveSkillsDir() {
         if (skillsDir != null && !skillsDir.isBlank()) {
             log.info("Using explicitly provided skills directory: {}", skillsDir);
             return skillsDir;

--- a/sentinel-ai-examples/src/main/java/com/phonepe/sentinelai/examples/texttosql/mcp/SqliteMcpServer.java
+++ b/sentinel-ai-examples/src/main/java/com/phonepe/sentinelai/examples/texttosql/mcp/SqliteMcpServer.java
@@ -31,15 +31,8 @@ import io.modelcontextprotocol.server.transport.HttpServletSseServerTransportPro
 import io.modelcontextprotocol.server.transport.StdioServerTransportProvider;
 import io.modelcontextprotocol.spec.McpSchema;
 import java.nio.file.Paths;
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.ResultSet;
-import java.sql.ResultSetMetaData;
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import lombok.SneakyThrows;
@@ -137,9 +130,10 @@ public class SqliteMcpServer implements Callable<Integer> {
     public Integer call() {
         DatabaseInitializer.ensureInitialised(Paths.get(dbPath).toAbsolutePath());
         log.info("SQLite MCP server starting [transport={}, dbPath={}]", transport, dbPath);
+        final SqliteQueryEngine engine = new SqliteQueryEngine(dbPath);
         return switch (transport) {
-            case STDIO -> runStdioMode();
-            case SSE -> runSseMode();
+            case STDIO -> runStdioMode(engine);
+            case SSE -> runSseMode(engine);
         };
     }
 
@@ -153,7 +147,7 @@ public class SqliteMcpServer implements Callable<Integer> {
      * <p>Blocks the main thread until the parent process closes the pipe.
      */
     @SneakyThrows
-    private Integer runStdioMode() {
+    private Integer runStdioMode(SqliteQueryEngine engine) {
         final ObjectMapper mapper = JsonUtils.createMapper();
         final var jsonMapper = new JacksonMcpJsonMapper(mapper);
 
@@ -166,16 +160,18 @@ public class SqliteMcpServer implements Callable<Integer> {
                         .capabilities(McpSchema.ServerCapabilities.builder().tools(false).build())
                         .toolCall(
                                 executeQueryTool(jsonMapper),
-                                (exchange, args) -> handleExecuteQuery(args.arguments(), mapper))
+                                (exchange, args) ->
+                                        engine.executeQuery(args.arguments(), mapper))
                         .toolCall(
                                 listTablesTool(jsonMapper),
-                                (exchange, args) -> handleListTables(mapper))
+                                (exchange, args) -> engine.listTables(mapper))
                         .toolCall(
                                 getTableSchemaTool(jsonMapper),
-                                (exchange, args) -> handleGetTableSchema(args.arguments(), mapper))
+                                (exchange, args) ->
+                                        engine.getTableSchema(args.arguments(), mapper))
                         .toolCall(
                                 getDatabaseInfoTool(jsonMapper),
-                                (exchange, args) -> handleGetDatabaseInfo(mapper))
+                                (exchange, args) -> engine.getDatabaseInfo(mapper))
                         .build();
 
         log.info("SQLite MCP server started in STDIO mode. Database: {}", dbPath);
@@ -193,7 +189,7 @@ public class SqliteMcpServer implements Callable<Integer> {
      * <p>Starts an embedded Jetty server on {@link #port} and blocks until the server is stopped.
      */
     @SneakyThrows
-    private Integer runSseMode() {
+    private Integer runSseMode(SqliteQueryEngine engine) {
         final ObjectMapper mapper = JsonUtils.createMapper();
         final var jsonMapper = new JacksonMcpJsonMapper(mapper);
 
@@ -210,16 +206,16 @@ public class SqliteMcpServer implements Callable<Integer> {
                         .capabilities(McpSchema.ServerCapabilities.builder().tools(false).build())
                         .tool(
                                 executeQueryTool(jsonMapper),
-                                (exchange, args) -> handleExecuteQuery(args, mapper))
+                                (exchange, args) -> engine.executeQuery(args, mapper))
                         .tool(
                                 listTablesTool(jsonMapper),
-                                (exchange, args) -> handleListTables(mapper))
+                                (exchange, args) -> engine.listTables(mapper))
                         .tool(
                                 getTableSchemaTool(jsonMapper),
-                                (exchange, args) -> handleGetTableSchema(args, mapper))
+                                (exchange, args) -> engine.getTableSchema(args, mapper))
                         .tool(
                                 getDatabaseInfoTool(jsonMapper),
-                                (exchange, args) -> handleGetDatabaseInfo(mapper))
+                                (exchange, args) -> engine.getDatabaseInfo(mapper))
                         .build();
 
         // Embed the SSE transport provider in a Jetty 12 (ee10) server
@@ -326,173 +322,27 @@ public class SqliteMcpServer implements Callable<Integer> {
     }
 
     // -------------------------------------------------------------------------
-    // Tool handlers
+    // Legacy private delegates — kept so that existing reflection-based tests
+    // in SqliteMcpServerTest continue to compile and pass.  All logic lives in
+    // SqliteQueryEngine; these wrappers simply forward the call.
     // -------------------------------------------------------------------------
 
-    @SneakyThrows
     private McpSchema.CallToolResult handleExecuteQuery(
             Map<String, Object> args, ObjectMapper mapper) {
-        final String sql = (String) args.get("sql");
-        if (sql == null || sql.isBlank()) {
-            return error("Field 'sql' is required");
-        }
-
-        final String upper = sql.trim().toUpperCase();
-        final Set<String> writePrefixes =
-                Set.of(
-                        "INSERT",
-                        "UPDATE",
-                        "DELETE",
-                        "DROP",
-                        "ALTER",
-                        "CREATE",
-                        "REPLACE",
-                        "TRUNCATE",
-                        "MERGE");
-        for (final String prefix : writePrefixes) {
-            if (upper.startsWith(prefix)) {
-                return error(
-                        "Write DML statements are not allowed via this endpoint. "
-                                + "Statement starts with: "
-                                + prefix);
-            }
-        }
-
-        @SuppressWarnings("unchecked")
-        final List<Object> values =
-                args.containsKey("values") ? (List<Object>) args.get("values") : List.of();
-
-        log.info("Executing SQL: {}", sql);
-        final long startMs = System.currentTimeMillis();
-        try (Connection conn = connect()) {
-            final List<Map<String, Object>> rows = executeSelect(conn, sql, values);
-            final long elapsed = System.currentTimeMillis() - startMs;
-
-            final List<String> jsonRows = new ArrayList<>(rows.size());
-            for (final Map<String, Object> row : rows) {
-                jsonRows.add(mapper.writeValueAsString(row));
-            }
-
-            final Map<String, Object> result = new LinkedHashMap<>();
-            result.put("sql", sql);
-            result.put("rows", jsonRows);
-            result.put("rowCount", rows.size());
-            result.put("executionTimeMs", elapsed);
-            return success(mapper.writeValueAsString(result));
-        } catch (Exception e) {
-            log.error("SQL execution error: {}", e.getMessage());
-            return error("SQL execution failed: " + e.getMessage());
-        }
+        return new SqliteQueryEngine(dbPath).executeQuery(args, mapper);
     }
 
-    @SneakyThrows
     private McpSchema.CallToolResult handleListTables(ObjectMapper mapper) {
-        try (Connection conn = connect()) {
-            final List<Map<String, Object>> rows =
-                    executeSelect(
-                            conn,
-                            "SELECT name FROM sqlite_master WHERE type='table' "
-                                    + "AND name NOT LIKE 'sqlite_%' ORDER BY name",
-                            List.of());
-            final List<String> tables = rows.stream().map(r -> (String) r.get("name")).toList();
-            return success(mapper.writeValueAsString(Map.of("tables", tables)));
-        } catch (Exception e) {
-            return error("Failed to list tables: " + e.getMessage());
-        }
+        return new SqliteQueryEngine(dbPath).listTables(mapper);
     }
 
-    @SneakyThrows
     private McpSchema.CallToolResult handleGetTableSchema(
             Map<String, Object> args, ObjectMapper mapper) {
-        final String tableName = (String) args.get("tableName");
-        if (tableName == null || tableName.isBlank()) {
-            return error("Field 'tableName' is required");
-        }
-        try (Connection conn = connect()) {
-            final List<Map<String, Object>> columns =
-                    executeSelect(conn, "PRAGMA table_info(\"" + tableName + "\")", List.of());
-            if (columns.isEmpty()) {
-                return error("Table not found: " + tableName);
-            }
-            return success(
-                    mapper.writeValueAsString(Map.of("tableName", tableName, "columns", columns)));
-        } catch (Exception e) {
-            return error("Failed to get schema for table '" + tableName + "': " + e.getMessage());
-        }
+        return new SqliteQueryEngine(dbPath).getTableSchema(args, mapper);
     }
 
-    @SneakyThrows
     private McpSchema.CallToolResult handleGetDatabaseInfo(ObjectMapper mapper) {
-        try (Connection conn = connect()) {
-            final List<Map<String, Object>> tables =
-                    executeSelect(
-                            conn,
-                            "SELECT name FROM sqlite_master WHERE type='table' "
-                                    + "AND name NOT LIKE 'sqlite_%'",
-                            List.of());
-            final List<Map<String, Object>> pageSize =
-                    executeSelect(conn, "PRAGMA page_size", List.of());
-            final List<Map<String, Object>> pageCount =
-                    executeSelect(conn, "PRAGMA page_count", List.of());
-
-            final long ps =
-                    pageSize.isEmpty()
-                            ? 0L
-                            : Long.parseLong(String.valueOf(pageSize.get(0).get("page_size")));
-            final long pc =
-                    pageCount.isEmpty()
-                            ? 0L
-                            : Long.parseLong(String.valueOf(pageCount.get(0).get("page_count")));
-
-            final Map<String, Object> info = new LinkedHashMap<>();
-            info.put("databasePath", dbPath);
-            info.put("tableCount", tables.size());
-            info.put("tables", tables.stream().map(r -> r.get("name")).toList());
-            info.put("approximateSizeBytes", ps * pc);
-            return success(mapper.writeValueAsString(info));
-        } catch (Exception e) {
-            return error("Failed to get database info: " + e.getMessage());
-        }
-    }
-
-    // -------------------------------------------------------------------------
-    // JDBC helpers
-    // -------------------------------------------------------------------------
-
-    @SneakyThrows
-    private Connection connect() {
-        return DriverManager.getConnection("jdbc:sqlite:" + dbPath);
-    }
-
-    @SneakyThrows
-    private List<Map<String, Object>> executeSelect(
-            Connection conn, String sql, List<Object> params) {
-        try (final var stmt = conn.prepareStatement(sql)) {
-            for (int i = 0; i < params.size(); i++) {
-                stmt.setObject(i + 1, params.get(i));
-            }
-            try (ResultSet rs = stmt.executeQuery()) {
-                final ResultSetMetaData meta = rs.getMetaData();
-                final int cols = meta.getColumnCount();
-                final List<Map<String, Object>> rows = new ArrayList<>();
-                while (rs.next()) {
-                    final Map<String, Object> row = new LinkedHashMap<>();
-                    for (int c = 1; c <= cols; c++) {
-                        row.put(meta.getColumnName(c), rs.getObject(c));
-                    }
-                    rows.add(row);
-                }
-                return rows;
-            }
-        }
-    }
-
-    private McpSchema.CallToolResult success(String text) {
-        return new McpSchema.CallToolResult(text, false);
-    }
-
-    private McpSchema.CallToolResult error(String message) {
-        return new McpSchema.CallToolResult(message, true);
+        return new SqliteQueryEngine(dbPath).getDatabaseInfo(mapper);
     }
 
     // -------------------------------------------------------------------------

--- a/sentinel-ai-examples/src/main/java/com/phonepe/sentinelai/examples/texttosql/mcp/SqliteQueryEngine.java
+++ b/sentinel-ai-examples/src/main/java/com/phonepe/sentinelai/examples/texttosql/mcp/SqliteQueryEngine.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright (c) 2025 Original Author(s), PhonePe India Pvt. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.phonepe.sentinelai.examples.texttosql.mcp;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.modelcontextprotocol.spec.McpSchema;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Executes SQL read operations against an SQLite database and returns {@link
+ * McpSchema.CallToolResult} values suitable for use as MCP tool responses.
+ *
+ * <p>This class contains all of the business logic that was previously embedded as private methods
+ * inside {@link SqliteMcpServer}. Extracting it here makes the query logic independently testable
+ * without requiring any MCP server infrastructure.
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class SqliteQueryEngine {
+
+    private final String dbPath;
+
+    // -------------------------------------------------------------------------
+    // Public tool-handler API
+    // -------------------------------------------------------------------------
+
+    /**
+     * Executes a read-only SQL SELECT statement and returns the rows as JSON.
+     *
+     * <p>Write statements (INSERT, UPDATE, DELETE, DROP, ALTER, CREATE, REPLACE, TRUNCATE, MERGE)
+     * are rejected with an error result.
+     */
+    @SneakyThrows
+    public McpSchema.CallToolResult executeQuery(Map<String, Object> args, ObjectMapper mapper) {
+        final String sql = (String) args.get("sql");
+        if (sql == null || sql.isBlank()) {
+            return error("Field 'sql' is required");
+        }
+
+        final String upper = sql.trim().toUpperCase();
+        final Set<String> writePrefixes =
+                Set.of(
+                        "INSERT",
+                        "UPDATE",
+                        "DELETE",
+                        "DROP",
+                        "ALTER",
+                        "CREATE",
+                        "REPLACE",
+                        "TRUNCATE",
+                        "MERGE");
+        for (final String prefix : writePrefixes) {
+            if (upper.startsWith(prefix)) {
+                return error(
+                        "Write DML statements are not allowed via this endpoint. "
+                                + "Statement starts with: "
+                                + prefix);
+            }
+        }
+
+        @SuppressWarnings("unchecked")
+        final List<Object> values =
+                args.containsKey("values") ? (List<Object>) args.get("values") : List.of();
+
+        log.info("Executing SQL: {}", sql);
+        final long startMs = System.currentTimeMillis();
+        try (Connection conn = connect()) {
+            final List<Map<String, Object>> rows = executeSelect(conn, sql, values);
+            final long elapsed = System.currentTimeMillis() - startMs;
+
+            final List<String> jsonRows = new ArrayList<>(rows.size());
+            for (final Map<String, Object> row : rows) {
+                jsonRows.add(mapper.writeValueAsString(row));
+            }
+
+            final Map<String, Object> result = new LinkedHashMap<>();
+            result.put("sql", sql);
+            result.put("rows", jsonRows);
+            result.put("rowCount", rows.size());
+            result.put("executionTimeMs", elapsed);
+            return success(mapper.writeValueAsString(result));
+        } catch (Exception e) {
+            log.error("SQL execution error: {}", e.getMessage());
+            return error("SQL execution failed: " + e.getMessage());
+        }
+    }
+
+    /** Lists all user-defined tables in the SQLite database. */
+    @SneakyThrows
+    public McpSchema.CallToolResult listTables(ObjectMapper mapper) {
+        try (Connection conn = connect()) {
+            final List<Map<String, Object>> rows =
+                    executeSelect(
+                            conn,
+                            "SELECT name FROM sqlite_master WHERE type='table' "
+                                    + "AND name NOT LIKE 'sqlite_%' ORDER BY name",
+                            List.of());
+            final List<String> tables = rows.stream().map(r -> (String) r.get("name")).toList();
+            return success(mapper.writeValueAsString(Map.of("tables", tables)));
+        } catch (Exception e) {
+            return error("Failed to list tables: " + e.getMessage());
+        }
+    }
+
+    /** Returns the column definitions for a specific table. */
+    @SneakyThrows
+    public McpSchema.CallToolResult getTableSchema(Map<String, Object> args, ObjectMapper mapper) {
+        final String tableName = (String) args.get("tableName");
+        if (tableName == null || tableName.isBlank()) {
+            return error("Field 'tableName' is required");
+        }
+        try (Connection conn = connect()) {
+            final List<Map<String, Object>> columns =
+                    executeSelect(conn, "PRAGMA table_info(\"" + tableName + "\")", List.of());
+            if (columns.isEmpty()) {
+                return error("Table not found: " + tableName);
+            }
+            return success(
+                    mapper.writeValueAsString(Map.of("tableName", tableName, "columns", columns)));
+        } catch (Exception e) {
+            return error("Failed to get schema for table '" + tableName + "': " + e.getMessage());
+        }
+    }
+
+    /** Returns high-level metadata about the database (path, table count, size). */
+    @SneakyThrows
+    public McpSchema.CallToolResult getDatabaseInfo(ObjectMapper mapper) {
+        try (Connection conn = connect()) {
+            final List<Map<String, Object>> tables =
+                    executeSelect(
+                            conn,
+                            "SELECT name FROM sqlite_master WHERE type='table' "
+                                    + "AND name NOT LIKE 'sqlite_%'",
+                            List.of());
+            final List<Map<String, Object>> pageSize =
+                    executeSelect(conn, "PRAGMA page_size", List.of());
+            final List<Map<String, Object>> pageCount =
+                    executeSelect(conn, "PRAGMA page_count", List.of());
+
+            final long ps =
+                    pageSize.isEmpty()
+                            ? 0L
+                            : Long.parseLong(String.valueOf(pageSize.get(0).get("page_size")));
+            final long pc =
+                    pageCount.isEmpty()
+                            ? 0L
+                            : Long.parseLong(String.valueOf(pageCount.get(0).get("page_count")));
+
+            final Map<String, Object> info = new LinkedHashMap<>();
+            info.put("databasePath", dbPath);
+            info.put("tableCount", tables.size());
+            info.put("tables", tables.stream().map(r -> r.get("name")).toList());
+            info.put("approximateSizeBytes", ps * pc);
+            return success(mapper.writeValueAsString(info));
+        } catch (Exception e) {
+            return error("Failed to get database info: " + e.getMessage());
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // JDBC helpers
+    // -------------------------------------------------------------------------
+
+    @SneakyThrows
+    private Connection connect() {
+        return DriverManager.getConnection("jdbc:sqlite:" + dbPath);
+    }
+
+    @SneakyThrows
+    private List<Map<String, Object>> executeSelect(
+            Connection conn, String sql, List<Object> params) {
+        try (final var stmt = conn.prepareStatement(sql)) {
+            for (int i = 0; i < params.size(); i++) {
+                stmt.setObject(i + 1, params.get(i));
+            }
+            try (ResultSet rs = stmt.executeQuery()) {
+                final ResultSetMetaData meta = rs.getMetaData();
+                final int cols = meta.getColumnCount();
+                final List<Map<String, Object>> rows = new ArrayList<>();
+                while (rs.next()) {
+                    final Map<String, Object> row = new LinkedHashMap<>();
+                    for (int c = 1; c <= cols; c++) {
+                        row.put(meta.getColumnName(c), rs.getObject(c));
+                    }
+                    rows.add(row);
+                }
+                return rows;
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Result helpers
+    // -------------------------------------------------------------------------
+
+    private McpSchema.CallToolResult success(String text) {
+        return new McpSchema.CallToolResult(text, false);
+    }
+
+    private McpSchema.CallToolResult error(String message) {
+        return new McpSchema.CallToolResult(message, true);
+    }
+}

--- a/sentinel-ai-examples/src/main/java/com/phonepe/sentinelai/examples/texttosql/server/SqliteRestServer.java
+++ b/sentinel-ai-examples/src/main/java/com/phonepe/sentinelai/examples/texttosql/server/SqliteRestServer.java
@@ -137,7 +137,7 @@ public class SqliteRestServer extends Application<SqliteRestConfig> {
      * placeholders, and returns the absolute path of that temp file so Dropwizard can parse it.
      */
     @SneakyThrows
-    private static String buildInlineConfig(int port) {
+    static String buildInlineConfig(int port) {
         final String template;
         try (var stream =
                 SqliteRestServer.class.getClassLoader().getResourceAsStream("dw/config.yml")) {
@@ -169,7 +169,7 @@ public class SqliteRestServer extends Application<SqliteRestConfig> {
 
     /** Polls {@code host:port} until a TCP connection succeeds or the timeout elapses. */
     @SneakyThrows
-    private static void waitForPort(String host, int port, long timeoutMs)
+    static void waitForPort(String host, int port, long timeoutMs)
             throws InterruptedException {
         final long deadline = System.currentTimeMillis() + timeoutMs;
         while (System.currentTimeMillis() < deadline) {

--- a/sentinel-ai-examples/src/test/java/com/phonepe/sentinelai/examples/texttosql/mcp/SqliteQueryEngineTest.java
+++ b/sentinel-ai-examples/src/test/java/com/phonepe/sentinelai/examples/texttosql/mcp/SqliteQueryEngineTest.java
@@ -1,0 +1,350 @@
+/*
+ * Copyright (c) 2025 Original Author(s), PhonePe India Pvt. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.phonepe.sentinelai.examples.texttosql.mcp;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.phonepe.sentinelai.core.utils.JsonUtils;
+import com.phonepe.sentinelai.examples.texttosql.tools.DatabaseInitializer;
+import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Tests for {@link SqliteQueryEngine}.
+ *
+ * <p>All handler methods are public, so no reflection is required.
+ */
+@DisplayName("SqliteQueryEngine")
+class SqliteQueryEngineTest {
+
+    @TempDir
+    static Path tempDir;
+
+    static SqliteQueryEngine engine;
+    static SqliteQueryEngine badEngine;
+    static ObjectMapper mapper;
+
+    @BeforeAll
+    static void setUp() throws Exception {
+        final Path dbPath = tempDir.resolve("query-engine-test.db");
+        DatabaseInitializer.ensureInitialised(dbPath);
+
+        engine = new SqliteQueryEngine(dbPath.toAbsolutePath().toString());
+        badEngine = new SqliteQueryEngine("/nonexistent/path/to/db.sqlite");
+
+        mapper = JsonUtils.createMapper();
+    }
+
+    private static String firstText(McpSchema.CallToolResult result) {
+        if (result.content() == null || result.content().isEmpty()) {
+            return "";
+        }
+        final McpSchema.Content first = result.content().get(0);
+        if (first instanceof TextContent tc) {
+            return tc.text() != null ? tc.text() : "";
+        }
+        return first.toString();
+    }
+
+    // =========================================================================
+    // executeQuery
+    // =========================================================================
+
+    @Nested
+    @DisplayName("executeQuery")
+    class ExecuteQueryTests {
+
+        @Test
+        @DisplayName("returns rows for a valid SELECT statement")
+        void returnsRowsForValidSelect() {
+            final McpSchema.CallToolResult result =
+                    engine.executeQuery(Map.of("sql", "SELECT 1 AS one"), mapper);
+            assertNotNull(result);
+            assertFalse(Boolean.TRUE.equals(result.isError()), "Valid SELECT should succeed");
+            assertTrue(firstText(result).contains("rows"));
+        }
+
+        @Test
+        @DisplayName("returns rows for a SELECT from the users table")
+        void returnsRowsFromUsersTable() {
+            final McpSchema.CallToolResult result =
+                    engine.executeQuery(Map.of("sql", "SELECT user_id FROM users LIMIT 3"), mapper);
+            assertNotNull(result);
+            assertFalse(Boolean.TRUE.equals(result.isError()), "SELECT from users should succeed");
+            assertTrue(firstText(result).contains("rows"));
+        }
+
+        @Test
+        @DisplayName("returns error when sql field is absent")
+        void returnsErrorWhenSqlAbsent() {
+            final McpSchema.CallToolResult result = engine.executeQuery(Map.of(), mapper);
+            assertTrue(Boolean.TRUE.equals(result.isError()));
+            assertTrue(firstText(result).contains("'sql' is required"));
+        }
+
+        @Test
+        @DisplayName("returns error when sql field is blank")
+        void returnsErrorWhenSqlBlank() {
+            final McpSchema.CallToolResult result =
+                    engine.executeQuery(Map.of("sql", "   "), mapper);
+            assertTrue(Boolean.TRUE.equals(result.isError()));
+        }
+
+        @Test
+        @DisplayName("rejects INSERT statements")
+        void rejectsInsert() {
+            final McpSchema.CallToolResult result =
+                    engine.executeQuery(
+                            Map.of("sql", "INSERT INTO users (id) VALUES (99999)"), mapper);
+            assertTrue(Boolean.TRUE.equals(result.isError()));
+            assertTrue(firstText(result).contains("INSERT"));
+        }
+
+        @Test
+        @DisplayName("rejects DELETE statements")
+        void rejectsDelete() {
+            final McpSchema.CallToolResult result =
+                    engine.executeQuery(
+                            Map.of("sql", "DELETE FROM users WHERE id = 99999"), mapper);
+            assertTrue(Boolean.TRUE.equals(result.isError()));
+        }
+
+        @Test
+        @DisplayName("rejects UPDATE statements")
+        void rejectsUpdate() {
+            final McpSchema.CallToolResult result =
+                    engine.executeQuery(
+                            Map.of("sql", "UPDATE users SET id = 0 WHERE id = 99999"), mapper);
+            assertTrue(Boolean.TRUE.equals(result.isError()));
+        }
+
+        @Test
+        @DisplayName("rejects DROP statements")
+        void rejectsDrop() {
+            final McpSchema.CallToolResult result =
+                    engine.executeQuery(Map.of("sql", "DROP TABLE users"), mapper);
+            assertTrue(Boolean.TRUE.equals(result.isError()));
+        }
+
+        @Test
+        @DisplayName("rejects CREATE statements")
+        void rejectsCreate() {
+            final McpSchema.CallToolResult result =
+                    engine.executeQuery(Map.of("sql", "CREATE TABLE foo (id INT)"), mapper);
+            assertTrue(Boolean.TRUE.equals(result.isError()));
+        }
+
+        @Test
+        @DisplayName("rejects ALTER statements")
+        void rejectsAlter() {
+            final McpSchema.CallToolResult result =
+                    engine.executeQuery(
+                            Map.of("sql", "ALTER TABLE users ADD COLUMN foo TEXT"), mapper);
+            assertTrue(Boolean.TRUE.equals(result.isError()));
+        }
+
+        @Test
+        @DisplayName("rejects TRUNCATE statements")
+        void rejectsTruncate() {
+            final McpSchema.CallToolResult result =
+                    engine.executeQuery(Map.of("sql", "TRUNCATE TABLE users"), mapper);
+            assertTrue(Boolean.TRUE.equals(result.isError()));
+        }
+
+        @Test
+        @DisplayName("rejects MERGE statements")
+        void rejectsMerge() {
+            final McpSchema.CallToolResult result =
+                    engine.executeQuery(Map.of("sql", "MERGE INTO users USING src ON x = y"), mapper);
+            assertTrue(Boolean.TRUE.equals(result.isError()));
+        }
+
+        @Test
+        @DisplayName("rejects REPLACE statements")
+        void rejectsReplace() {
+            final McpSchema.CallToolResult result =
+                    engine.executeQuery(
+                            Map.of("sql", "REPLACE INTO users (id) VALUES (1)"), mapper);
+            assertTrue(Boolean.TRUE.equals(result.isError()));
+        }
+
+        @Test
+        @DisplayName("executes with explicit empty values list")
+        void executesWithEmptyValuesList() {
+            final McpSchema.CallToolResult result =
+                    engine.executeQuery(
+                            Map.of("sql", "SELECT COUNT(*) FROM users", "values", List.of()),
+                            mapper);
+            assertFalse(Boolean.TRUE.equals(result.isError()));
+        }
+
+        @Test
+        @DisplayName("returns error for invalid SQL syntax")
+        void returnsErrorForInvalidSql() {
+            final McpSchema.CallToolResult result =
+                    engine.executeQuery(Map.of("sql", "SELECT FROM INVALID SYNTAX !!!"), mapper);
+            assertTrue(Boolean.TRUE.equals(result.isError()));
+        }
+
+        @Test
+        @DisplayName("returns error when database is not accessible")
+        void returnsErrorForBadDbPath() {
+            final McpSchema.CallToolResult result =
+                    badEngine.executeQuery(Map.of("sql", "SELECT 1"), mapper);
+            assertTrue(Boolean.TRUE.equals(result.isError()));
+        }
+
+        @Test
+        @DisplayName("executes query with bound parameter values")
+        void executesQueryWithBoundParams() {
+            final McpSchema.CallToolResult result =
+                    engine.executeQuery(
+                            Map.of(
+                                    "sql",
+                                    "SELECT user_id FROM users WHERE user_id = ?",
+                                    "values",
+                                    List.of(1)),
+                            mapper);
+            assertNotNull(result);
+            // May or may not find rows depending on seeded data — just assert no error from JDBC
+            assertFalse(
+                    firstText(result).contains("SQL execution failed"),
+                    "Parameterised SELECT should not fail at the JDBC level");
+        }
+    }
+
+    // =========================================================================
+    // listTables
+    // =========================================================================
+
+    @Nested
+    @DisplayName("listTables")
+    class ListTablesTests {
+
+        @Test
+        @DisplayName("returns a non-error result containing a tables list")
+        void returnsTablesList() {
+            final McpSchema.CallToolResult result = engine.listTables(mapper);
+            assertNotNull(result);
+            assertFalse(Boolean.TRUE.equals(result.isError()));
+            assertTrue(firstText(result).contains("tables"));
+        }
+
+        @Test
+        @DisplayName("returns error when database is not accessible")
+        void returnsErrorForBadDbPath() {
+            final McpSchema.CallToolResult result = badEngine.listTables(mapper);
+            assertTrue(Boolean.TRUE.equals(result.isError()));
+            assertTrue(firstText(result).contains("Failed to list tables"));
+        }
+    }
+
+    // =========================================================================
+    // getTableSchema
+    // =========================================================================
+
+    @Nested
+    @DisplayName("getTableSchema")
+    class GetTableSchemaTests {
+
+        @Test
+        @DisplayName("returns schema for an existing table")
+        void returnsSchemaForExistingTable() {
+            final McpSchema.CallToolResult result =
+                    engine.getTableSchema(Map.of("tableName", "users"), mapper);
+            assertNotNull(result);
+            assertFalse(Boolean.TRUE.equals(result.isError()));
+            assertTrue(firstText(result).contains("users"));
+        }
+
+        @Test
+        @DisplayName("returns error when tableName is absent")
+        void returnsErrorWhenTableNameAbsent() {
+            final McpSchema.CallToolResult result = engine.getTableSchema(Map.of(), mapper);
+            assertTrue(Boolean.TRUE.equals(result.isError()));
+            assertTrue(firstText(result).contains("'tableName' is required"));
+        }
+
+        @Test
+        @DisplayName("returns error when tableName is blank")
+        void returnsErrorWhenTableNameBlank() {
+            final McpSchema.CallToolResult result =
+                    engine.getTableSchema(Map.of("tableName", "   "), mapper);
+            assertTrue(Boolean.TRUE.equals(result.isError()));
+        }
+
+        @Test
+        @DisplayName("returns error for unknown table")
+        void returnsErrorForUnknownTable() {
+            final McpSchema.CallToolResult result =
+                    engine.getTableSchema(Map.of("tableName", "nonexistent_xyz"), mapper);
+            assertTrue(Boolean.TRUE.equals(result.isError()));
+            assertTrue(firstText(result).contains("Table not found"));
+        }
+
+        @Test
+        @DisplayName("returns error when database is not accessible")
+        void returnsErrorForBadDbPath() {
+            final McpSchema.CallToolResult result =
+                    badEngine.getTableSchema(Map.of("tableName", "users"), mapper);
+            assertTrue(Boolean.TRUE.equals(result.isError()));
+        }
+    }
+
+    // =========================================================================
+    // getDatabaseInfo
+    // =========================================================================
+
+    @Nested
+    @DisplayName("getDatabaseInfo")
+    class GetDatabaseInfoTests {
+
+        @Test
+        @DisplayName("returns database metadata including tableCount")
+        void returnsDatabaseMetadata() {
+            final McpSchema.CallToolResult result = engine.getDatabaseInfo(mapper);
+            assertNotNull(result);
+            assertFalse(Boolean.TRUE.equals(result.isError()));
+            assertTrue(firstText(result).contains("tableCount"));
+        }
+
+        @Test
+        @DisplayName("returns approximateSizeBytes in the response")
+        void returnsApproximateSizeBytes() {
+            final McpSchema.CallToolResult result = engine.getDatabaseInfo(mapper);
+            assertFalse(Boolean.TRUE.equals(result.isError()));
+            assertTrue(firstText(result).contains("approximateSizeBytes"));
+        }
+
+        @Test
+        @DisplayName("returns error when database is not accessible")
+        void returnsErrorForBadDbPath() {
+            final McpSchema.CallToolResult result = badEngine.getDatabaseInfo(mapper);
+            assertTrue(Boolean.TRUE.equals(result.isError()));
+            assertTrue(firstText(result).contains("Failed to get database info"));
+        }
+    }
+}

--- a/sentinel-ai-examples/src/test/java/com/phonepe/sentinelai/examples/texttosql/server/SqliteRestServerHelpersTest.java
+++ b/sentinel-ai-examples/src/test/java/com/phonepe/sentinelai/examples/texttosql/server/SqliteRestServerHelpersTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2025 Original Author(s), PhonePe India Pvt. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.phonepe.sentinelai.examples.texttosql.server;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for the package-visible helper methods of {@link SqliteRestServer}.
+ *
+ * <p>These helpers are directly accessible from the same package — no reflection needed.
+ */
+@DisplayName("SqliteRestServer helpers")
+class SqliteRestServerHelpersTest {
+
+    // =========================================================================
+    // buildInlineConfig
+    // =========================================================================
+
+    @Nested
+    @DisplayName("buildInlineConfig")
+    class BuildInlineConfigTests {
+
+        @Test
+        @DisplayName("returns path to a temp file that exists on disk")
+        void returnsTempFileThatExists() throws Exception {
+            final String configPath = SqliteRestServer.buildInlineConfig(9876);
+            assertNotNull(configPath);
+            assertTrue(Files.exists(Path.of(configPath)), "Temp config file should exist");
+        }
+
+        @Test
+        @DisplayName("substitutes port into the generated config file content")
+        void substitutesPortInContent() throws Exception {
+            final int port = 12345;
+            final String configPath = SqliteRestServer.buildInlineConfig(port);
+            final String content = Files.readString(Path.of(configPath));
+            assertTrue(
+                    content.contains(String.valueOf(port)),
+                    "Generated config should contain the requested port number");
+        }
+
+        @Test
+        @DisplayName("does not contain shell-style placeholder tokens after substitution")
+        void noUnresolvedPlaceholders() throws Exception {
+            final String configPath = SqliteRestServer.buildInlineConfig(8080);
+            final String content = Files.readString(Path.of(configPath));
+            assertFalse(
+                    content.contains("${DW_PORT"),
+                    "Generated config must not contain unresolved DW_PORT placeholder");
+            assertFalse(
+                    content.contains("${DW_ADMIN_PORT"),
+                    "Generated config must not contain unresolved DW_ADMIN_PORT placeholder");
+        }
+
+        @Test
+        @DisplayName("admin port is port + 1")
+        void adminPortIsPortPlusOne() throws Exception {
+            final int port = 7777;
+            final String configPath = SqliteRestServer.buildInlineConfig(port);
+            final String content = Files.readString(Path.of(configPath));
+            assertTrue(
+                    content.contains(String.valueOf(port + 1)),
+                    "Generated config should contain the admin port (port + 1)");
+        }
+    }
+
+    // =========================================================================
+    // waitForPort
+    // =========================================================================
+
+    @Nested
+    @DisplayName("waitForPort")
+    class WaitForPortTests {
+
+        @Test
+        @DisplayName("throws IllegalStateException when port is not reachable within timeout")
+        void throwsWhenPortNotReachable() {
+            assertThrows(
+                    IllegalStateException.class,
+                    () -> SqliteRestServer.waitForPort("localhost", 1, 300L));
+        }
+
+        @Test
+        @DisplayName("error message mentions the timeout duration")
+        void errorMessageMentionsTimeout() {
+            final IllegalStateException ex =
+                    assertThrows(
+                            IllegalStateException.class,
+                            () -> SqliteRestServer.waitForPort("localhost", 1, 300L));
+            assertTrue(
+                    ex.getMessage().contains("did not start"),
+                    "Error should say server did not start");
+        }
+    }
+}

--- a/sentinel-ai-filesystem/src/test/java/com/phonepe/sentinelai/filesystem/skills/SkillRegistryEdgeCasesTest.java
+++ b/sentinel-ai-filesystem/src/test/java/com/phonepe/sentinelai/filesystem/skills/SkillRegistryEdgeCasesTest.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright (c) 2025 Original Author(s), PhonePe India Pvt. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.phonepe.sentinelai.filesystem.skills;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.Set;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Additional edge-case tests for {@link SkillRegistry} covering paths that are not exercised by
+ * {@link SkillRegistryTest}.
+ */
+@DisplayName("SkillRegistry edge cases")
+class SkillRegistryEdgeCasesTest {
+
+    private Path tempDir;
+    private SkillRegistry registry;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        tempDir = Files.createTempDirectory("skill-registry-edge-");
+        registry = new SkillRegistry();
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        Files.walk(tempDir)
+                .sorted(Comparator.reverseOrder())
+                .forEach(
+                        p -> {
+                            try {
+                                Files.delete(p);
+                            } catch (IOException ignored) {
+                                // best-effort cleanup
+                            }
+                        });
+    }
+
+    // =========================================================================
+    // discoverSkills — catch block when skill dir is malformed
+    // =========================================================================
+
+    @Nested
+    @DisplayName("discoverSkills — malformed skill directory")
+    class DiscoverMalformedSkillTests {
+
+        @Test
+        @DisplayName("skips a directory whose SKILL.md is missing, continues with others")
+        void skipsMalformedSkillAndContinues() throws IOException {
+            // A directory with NO SKILL.md — parser will throw, triggering the catch block
+            Files.createDirectories(tempDir.resolve("broken-skill"));
+
+            // A valid skill alongside the broken one
+            createSkill(tempDir, "good-skill", "Good skill description");
+
+            registry.discoverSkills(tempDir, Set.of());
+
+            // broken-skill should be silently skipped; good-skill should be loaded
+            assertFalse(
+                    registry.getSkillNames().contains("broken-skill"),
+                    "Malformed skill directory should be skipped");
+            assertTrue(
+                    registry.getSkillNames().contains("good-skill"),
+                    "Valid skill should still be discovered");
+        }
+    }
+
+    // =========================================================================
+    // loadSkill — skill is in catalog but its directory no longer exists
+    // =========================================================================
+
+    @Nested
+    @DisplayName("loadSkill — catalog entry with no matching directory")
+    class LoadSkillMissingDirTests {
+
+        @Test
+        @DisplayName("returns empty when skill directory has been removed after discovery")
+        void returnsEmptyWhenSkillDirRemoved() throws IOException {
+            createSkill(tempDir, "vanishing-skill", "Will disappear");
+            registry.discoverSkills(tempDir, Set.of());
+
+            // Remove the skill directory after discovery to simulate an out-of-sync catalog
+            final Path skillDir = tempDir.resolve("vanishing-skill");
+            Files.walk(skillDir)
+                    .sorted(Comparator.reverseOrder())
+                    .forEach(
+                            p -> {
+                                try {
+                                    Files.delete(p);
+                                } catch (IOException ignored) {
+                                    // best-effort
+                                }
+                            });
+
+            final var result = registry.loadSkill("vanishing-skill");
+            assertFalse(
+                    result.isPresent(),
+                    "loadSkill should return empty when the skill directory has been deleted");
+        }
+    }
+
+    // =========================================================================
+    // loadSkill — directory exists but SKILL.md is corrupt (parse failure)
+    // =========================================================================
+
+    @Nested
+    @DisplayName("loadSkill — SKILL.md present but corrupt")
+    class LoadSkillCorruptFileTests {
+
+        @Test
+        @DisplayName("returns empty when the SKILL.md cannot be parsed at load time")
+        void returnsEmptyWhenSkillMdCorrupt() throws IOException {
+            // Discover with a valid SKILL.md so the name lands in the catalog
+            createSkill(tempDir, "corrupt-skill", "Will be corrupted");
+            registry.discoverSkills(tempDir, Set.of());
+
+            // Overwrite SKILL.md with content that will fail the parser (no front-matter block)
+            Files.writeString(tempDir.resolve("corrupt-skill").resolve("SKILL.md"), "not valid");
+
+            final var result = registry.loadSkill("corrupt-skill");
+            assertFalse(
+                    result.isPresent(),
+                    "loadSkill should return empty when SKILL.md cannot be parsed");
+        }
+    }
+
+    // =========================================================================
+    // formatLoadedSkillsAsYaml — with loaded skills
+    // =========================================================================
+
+    @Nested
+    @DisplayName("formatLoadedSkillsAsYaml")
+    class FormatLoadedSkillsAsYamlTests {
+
+        @Test
+        @DisplayName("returns empty-list YAML when no skills have been loaded")
+        void returnsEmptyYamlWhenNoneLoaded() {
+            final String yaml = registry.formatLoadedSkillsAsYaml();
+            assertTrue(yaml.contains("loaded_skills: []"), "Should contain empty list marker");
+        }
+
+        @Test
+        @DisplayName("includes skill name and description for every loaded skill")
+        void includesNameAndDescriptionForLoadedSkills() throws IOException {
+            createSkill(tempDir, "alpha-skill", "Alpha description");
+            createSkill(tempDir, "beta-skill", "Beta description");
+            registry.discoverSkills(tempDir, Set.of());
+
+            registry.loadSkill("alpha-skill");
+            registry.loadSkill("beta-skill");
+
+            final String yaml = registry.formatLoadedSkillsAsYaml();
+            assertTrue(yaml.contains("alpha-skill"), "YAML should mention alpha-skill");
+            assertTrue(yaml.contains("Alpha description"), "YAML should mention alpha's description");
+            assertTrue(yaml.contains("beta-skill"), "YAML should mention beta-skill");
+            assertTrue(yaml.contains("Beta description"), "YAML should mention beta's description");
+        }
+    }
+
+    // =========================================================================
+    // loadSkillFromPath — path is a file, not a directory
+    // =========================================================================
+
+    @Nested
+    @DisplayName("loadSkillFromPath — file instead of directory")
+    class LoadSkillFromPathFileTests {
+
+        @Test
+        @DisplayName("throws IllegalArgumentException when the path points to a regular file")
+        void throwsWhenPathIsAFile() throws IOException {
+            final Path regularFile = tempDir.resolve("not-a-dir.txt");
+            Files.writeString(regularFile, "I am a file, not a directory");
+
+            assertThrows(
+                    IllegalArgumentException.class,
+                    () -> registry.loadSkillFromPath(regularFile),
+                    "Should throw when path is a regular file");
+        }
+    }
+
+    // =========================================================================
+    // getLoadedSkill — before and after loading
+    // =========================================================================
+
+    @Nested
+    @DisplayName("getLoadedSkill")
+    class GetLoadedSkillTests {
+
+        @Test
+        @DisplayName("returns empty before any skill is loaded")
+        void returnsEmptyBeforeLoad() {
+            assertTrue(registry.getLoadedSkill("anything").isEmpty());
+        }
+
+        @Test
+        @DisplayName("returns the skill after it has been loaded")
+        void returnsSkillAfterLoad() throws IOException {
+            createSkill(tempDir, "loaded-skill", "A loaded skill");
+            registry.discoverSkills(tempDir, Set.of());
+            registry.loadSkill("loaded-skill");
+
+            assertTrue(registry.getLoadedSkill("loaded-skill").isPresent());
+        }
+    }
+
+    // =========================================================================
+    // helpers
+    // =========================================================================
+
+    private static void createSkill(Path baseDir, String name, String description)
+            throws IOException {
+        final Path skillDir = baseDir.resolve(name);
+        Files.createDirectories(skillDir);
+        Files.writeString(
+                skillDir.resolve("SKILL.md"),
+                """
+                ---
+                name: %s
+                description: %s
+                ---
+
+                # %s Instructions
+                """.formatted(name, description, name));
+    }
+}


### PR DESCRIPTION
…ew code coverage

- Extract SqliteQueryEngine from SqliteMcpServer so all four SQL handler methods are public and directly testable without reflection
- SqliteMcpServer retains private delegates to keep existing reflection-based tests passing; new SqliteQueryEngineTest covers every handler and error branch directly
- Make TextToSqlCLI static helper methods package-private so same-package tests can call them without getDeclaredMethod/setAccessible
- Make SqliteRestServer.waitForPort and buildInlineConfig package-private; add SqliteRestServerHelpersTest covering config substitution and timeout
- Add SkillRegistryEdgeCasesTest covering: malformed skill directory (catch block in discoverSkills), vanished skill directory after discovery, corrupt SKILL.md at load time, formatLoadedSkillsAsYaml with loaded skills, loadSkillFromPath with a regular file, getLoadedSkill before and after load