### PR TITLE
Added DEFAULT tool choice mode

### DIFF
--- a/docs/docs/agents.md
+++ b/docs/docs/agents.md
@@ -219,6 +219,42 @@ final var model = new SimpleOpenAIModel<>(
 );
 ```
 
+The `toolChoice` field on `SimpleOpenAIModelOptions` controls the `tool_choice` parameter sent to the model. Sentinel AI
+automatically resolves the effective OpenAI `tool_choice` value by combining `toolChoice` with the active
+`outputGenerationMode`. This is needed because `TOOL_BASED` mode previously forced `tool_choice` to `required`,
+and some models (e.g. Qwen, Kimi on vLLM) do not call tools reliably in this configuration. The `toolChoice` option
+now allows you to override this behavior and set it to `auto` for such models.
+
+The resolution rules are:
+
+| `outputGenerationMode` | `toolChoice`        | Effective OpenAI `tool_choice` | Notes                                                                                           |
+|------------------------|---------------------|--------------------------------|-------------------------------------------------------------------------------------------------|
+| `TOOL_BASED`           | `REQUIRED`          | `required`                     |                                                                                                 |
+| `TOOL_BASED`           | `AUTO`              | `auto`                         |                                                                                                 |
+| `TOOL_BASED`           | `DEFAULT`           | `required`                     | Default for tool-based mode — model must call a tool to produce output.                         |
+| `STRUCTURED_OUTPUT`    | `REQUIRED`          | `required`                     | ⚠️ Warning logged: may cause infinite tool-call loops in structured-output mode.               |
+| `STRUCTURED_OUTPUT`    | `AUTO`              | `auto`                         |                                                                                                 |
+| `STRUCTURED_OUTPUT`    | `DEFAULT`           | `auto`                         | Default for structured-output mode — model chooses whether to call a tool.                      |
+
+!!!warning "REQUIRED + STRUCTURED_OUTPUT"
+    Setting `toolChoice` to `REQUIRED` while `outputGenerationMode` is `STRUCTURED_OUTPUT` is allowed but will emit a
+    warning at runtime. This combination can cause the model to enter an infinite tool-call loop. Prefer `AUTO` or
+    `DEFAULT` when using `STRUCTURED_OUTPUT`.
+
+```java
+// Use AUTO tool choice for models that ignore REQUIRED (e.g. Qwen, Kimi on vLLM)
+final var modelOptions = SimpleOpenAIModelOptions.builder()
+        .toolChoice(SimpleOpenAIModelOptions.ToolChoice.AUTO)
+        .build();
+
+final var model = new SimpleOpenAIModel<>(
+        "qwen-plus",
+        client,
+        objectMapper,
+        modelOptions
+);
+```
+
 ### Retry Setup
 The `RetrySetup` class is a configuration class that is used to configure the retry mechanism for model calls.
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.phonepe.sentinel-ai</groupId>
     <artifactId>sentinel-ai</artifactId>
-    <version>1.1.1-alpha7</version>
+    <version>1.1.1-alpha8</version>
     <name>Sentinel AI</name>
     <url>https://github.com/PhonePe/sentinel-ai</url>
     <description>Sentinel AI Agent Framework</description>

--- a/sentinel-ai-agent-memory/pom.xml
+++ b/sentinel-ai-agent-memory/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.phonepe.sentinel-ai</groupId>
         <artifactId>sentinel-ai</artifactId>
-        <version>1.1.1-alpha7</version>
+        <version>1.1.1-alpha8</version>
     </parent>
 
     <artifactId>sentinel-ai-agent-memory</artifactId>

--- a/sentinel-ai-bom/pom.xml
+++ b/sentinel-ai-bom/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.phonepe.sentinel-ai</groupId>
         <artifactId>sentinel-ai</artifactId>
-        <version>1.1.1-alpha7</version>
+        <version>1.1.1-alpha8</version>
     </parent>
 
     <artifactId>sentinel-ai-bom</artifactId>

--- a/sentinel-ai-configured-agents/pom.xml
+++ b/sentinel-ai-configured-agents/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.phonepe.sentinel-ai</groupId>
         <artifactId>sentinel-ai</artifactId>
-        <version>1.1.1-alpha7</version>
+        <version>1.1.1-alpha8</version>
     </parent>
 
     <artifactId>sentinel-ai-configured-agents</artifactId>

--- a/sentinel-ai-core/pom.xml
+++ b/sentinel-ai-core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.phonepe.sentinel-ai</groupId>
         <artifactId>sentinel-ai</artifactId>
-        <version>1.1.1-alpha7</version>
+        <version>1.1.1-alpha8</version>
     </parent>
 
     <artifactId>sentinel-ai-core</artifactId>

--- a/sentinel-ai-embedding/pom.xml
+++ b/sentinel-ai-embedding/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.phonepe.sentinel-ai</groupId>
         <artifactId>sentinel-ai</artifactId>
-        <version>1.1.1-alpha7</version>
+        <version>1.1.1-alpha8</version>
     </parent>
 
     <artifactId>sentinel-ai-embedding</artifactId>

--- a/sentinel-ai-evals/pom.xml
+++ b/sentinel-ai-evals/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.phonepe.sentinel-ai</groupId>
         <artifactId>sentinel-ai</artifactId>
-        <version>1.1.1-alpha7</version>
+        <version>1.1.1-alpha8</version>
     </parent>
 
     <artifactId>sentinel-ai-evals</artifactId>

--- a/sentinel-ai-examples/pom.xml
+++ b/sentinel-ai-examples/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.phonepe.sentinel-ai</groupId>
         <artifactId>sentinel-ai</artifactId>
-        <version>1.1.1-alpha7</version>
+        <version>1.1.1-alpha8</version>
     </parent>
 
     <artifactId>sentinel-ai-examples</artifactId>

--- a/sentinel-ai-filesystem/pom.xml
+++ b/sentinel-ai-filesystem/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.phonepe.sentinel-ai</groupId>
         <artifactId>sentinel-ai</artifactId>
-        <version>1.1.1-alpha7</version>
+        <version>1.1.1-alpha8</version>
     </parent>
 
     <artifactId>sentinel-ai-filesystem</artifactId>

--- a/sentinel-ai-instrumentation-otel/pom.xml
+++ b/sentinel-ai-instrumentation-otel/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.phonepe.sentinel-ai</groupId>
         <artifactId>sentinel-ai</artifactId>
-        <version>1.1.1-alpha7</version>
+        <version>1.1.1-alpha8</version>
     </parent>
 
     <artifactId>sentinel-ai-instrumentation-otel</artifactId>

--- a/sentinel-ai-models-simple-openai/pom.xml
+++ b/sentinel-ai-models-simple-openai/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.phonepe.sentinel-ai</groupId>
         <artifactId>sentinel-ai</artifactId>
-        <version>1.1.1-alpha7</version>
+        <version>1.1.1-alpha8</version>
     </parent>
 
     <artifactId>sentinel-ai-models-simple-openai</artifactId>

--- a/sentinel-ai-models-simple-openai/src/main/java/com/phonepe/sentinelai/models/SimpleOpenAIModel.java
+++ b/sentinel-ai-models-simple-openai/src/main/java/com/phonepe/sentinelai/models/SimpleOpenAIModel.java
@@ -70,6 +70,7 @@ import com.phonepe.sentinelai.core.utils.AgentUtils;
 import com.phonepe.sentinelai.core.utils.Pair;
 import com.phonepe.sentinelai.models.errors.AgentMessagesPreProcessorExecutionFailedException;
 import com.phonepe.sentinelai.models.errors.InvalidAgentMessagesException;
+import com.phonepe.sentinelai.models.utils.OpenAIMessageUtils;
 
 import lombok.Builder;
 import lombok.Getter;
@@ -1319,18 +1320,7 @@ public class SimpleOpenAIModel<M extends ChatCompletionServices> implements Mode
     }
 
     private ToolChoiceOption computeToolChoice(OutputGenerationMode outputGenerationMode) {
-        return switch (outputGenerationMode) {
-            case TOOL_BASED -> ToolChoiceOption.REQUIRED;
-            case STRUCTURED_OUTPUT -> switch (this.modelOptions
-                    .getToolChoice()) {
-                case REQUIRED -> {
-                    log.warn("Model is configured for STRUCTURED_OUTPUT generation mode, "
-                            + "but tool choice is set to REQUIRED. This might lead to infinite tool-call loops");
-                    yield ToolChoiceOption.REQUIRED;
-                }
-                case AUTO -> ToolChoiceOption.AUTO;
-            };
-        };
+        return OpenAIMessageUtils.resolveToolChoice(outputGenerationMode, this.modelOptions.getToolChoice());
     }
 
     /**

--- a/sentinel-ai-models-simple-openai/src/main/java/com/phonepe/sentinelai/models/SimpleOpenAIModelOptions.java
+++ b/sentinel-ai-models-simple-openai/src/main/java/com/phonepe/sentinelai/models/SimpleOpenAIModelOptions.java
@@ -18,6 +18,7 @@ package com.phonepe.sentinelai.models;
 
 import lombok.Builder;
 import lombok.Value;
+import lombok.extern.jackson.Jacksonized;
 
 import java.util.Objects;
 
@@ -26,7 +27,7 @@ import java.util.Objects;
  */
 @Value
 public class SimpleOpenAIModelOptions {
-    public static final ToolChoice DEFAULT_TOOL_CHOICE = ToolChoice.AUTO;
+    public static final ToolChoice DEFAULT_TOOL_CHOICE = ToolChoice.DEFAULT;
     public static final TokenCountingConfig DEFAULT_TOKEN_COUNTING_CONFIG = TokenCountingConfig.DEFAULT;
 
     public static final SimpleOpenAIModelOptions DEFAULT = new SimpleOpenAIModelOptions(DEFAULT_TOOL_CHOICE,
@@ -34,7 +35,9 @@ public class SimpleOpenAIModelOptions {
 
     public enum ToolChoice {
         REQUIRED, // Model will always call a tool. This is the default behavior.
-        AUTO // Model will call a tool only if it needs to
+        AUTO, // Model will call a tool only if it needs to
+        DEFAULT // Default based on the output generation mode. If output generation mode is set to TOOL_BASED, it will be same as REQUIRED.
+               // If output generation mode is set to STRUCTURED_OUTPUT, it will be same as AUTO.
     }
 
 
@@ -59,6 +62,7 @@ public class SimpleOpenAIModelOptions {
     TokenCountingConfig tokenCountingConfig;
 
     @Builder
+    @Jacksonized
     public SimpleOpenAIModelOptions(ToolChoice toolChoice,
                                     TokenCountingConfig tokenCountingConfig) {
         this.toolChoice = Objects.requireNonNullElse(toolChoice, DEFAULT_TOOL_CHOICE);

--- a/sentinel-ai-models-simple-openai/src/main/java/com/phonepe/sentinelai/models/utils/OpenAIMessageUtils.java
+++ b/sentinel-ai-models-simple-openai/src/main/java/com/phonepe/sentinelai/models/utils/OpenAIMessageUtils.java
@@ -17,6 +17,7 @@
 package com.phonepe.sentinelai.models.utils;
 
 import io.github.sashirestela.openai.common.function.FunctionCall;
+import io.github.sashirestela.openai.common.tool.ToolChoiceOption;
 import io.github.sashirestela.openai.common.tool.ToolType;
 import io.github.sashirestela.openai.domain.chat.ChatMessage;
 
@@ -36,7 +37,9 @@ import com.phonepe.sentinelai.core.agentmessages.requests.UserPrompt;
 import com.phonepe.sentinelai.core.agentmessages.responses.StructuredOutput;
 import com.phonepe.sentinelai.core.agentmessages.responses.Text;
 import com.phonepe.sentinelai.core.agentmessages.responses.ToolCall;
+import com.phonepe.sentinelai.core.model.OutputGenerationMode;
 import com.phonepe.sentinelai.core.utils.AgentUtils;
+import com.phonepe.sentinelai.models.SimpleOpenAIModelOptions;
 
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
@@ -164,4 +167,31 @@ public class OpenAIMessageUtils {
                 .toList();
 
     }
+
+    /**
+     * Resolves the tool choice option for OpenAI models based on the output generation mode
+     * and the tool choice specified in model options.
+     * This is needed because some models like qwen and kimi (on vllm) are not calling tools properly
+     * when output generation mode is set to TOOL_BASED and tool choice is set to REQUIRED.
+     */
+    public static ToolChoiceOption resolveToolChoice(OutputGenerationMode outputGenerationMode,
+                                                     SimpleOpenAIModelOptions.ToolChoice toolChoice) {
+        return switch (outputGenerationMode) {
+            case TOOL_BASED -> switch (toolChoice) {
+                case REQUIRED -> ToolChoiceOption.REQUIRED;
+                case AUTO -> ToolChoiceOption.AUTO;
+                case DEFAULT -> ToolChoiceOption.REQUIRED;
+            };
+            case STRUCTURED_OUTPUT -> switch (toolChoice) {
+                case REQUIRED -> {
+                    log.warn("Model is configured for STRUCTURED_OUTPUT generation mode, "
+                            + "but tool choice is set to REQUIRED. This might lead to infinite tool-call loops");
+                    yield ToolChoiceOption.REQUIRED;
+                }
+                case AUTO -> ToolChoiceOption.AUTO;
+                case DEFAULT -> ToolChoiceOption.AUTO;
+            };
+        };
+    }
+
 }

--- a/sentinel-ai-models-simple-openai/src/test/java/com/phonepe/sentinelai/models/OpenAIMessageUtilsTest.java
+++ b/sentinel-ai-models-simple-openai/src/test/java/com/phonepe/sentinelai/models/OpenAIMessageUtilsTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2025 Original Author(s), PhonePe India Pvt. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.phonepe.sentinelai.models;
+
+import io.github.sashirestela.openai.common.tool.ToolChoiceOption;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import com.phonepe.sentinelai.core.model.OutputGenerationMode;
+import com.phonepe.sentinelai.models.utils.OpenAIMessageUtils;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests {@link OpenAIMessageUtils#resolveToolChoice(OutputGenerationMode, SimpleOpenAIModelOptions.ToolChoice)}
+ */
+class OpenAIMessageUtilsTest {
+
+    static Stream<Arguments> resolveToolChoiceCases() {
+        return Stream.of(
+                         // TOOL_BASED mode
+                         Arguments.of(OutputGenerationMode.TOOL_BASED,
+                                      SimpleOpenAIModelOptions.ToolChoice.REQUIRED,
+                                      ToolChoiceOption.REQUIRED),
+                         Arguments.of(OutputGenerationMode.TOOL_BASED,
+                                      SimpleOpenAIModelOptions.ToolChoice.AUTO,
+                                      ToolChoiceOption.AUTO),
+                         Arguments.of(OutputGenerationMode.TOOL_BASED,
+                                      SimpleOpenAIModelOptions.ToolChoice.DEFAULT,
+                                      ToolChoiceOption.REQUIRED),
+                         // STRUCTURED_OUTPUT mode
+                         Arguments.of(OutputGenerationMode.STRUCTURED_OUTPUT,
+                                      SimpleOpenAIModelOptions.ToolChoice.REQUIRED,
+                                      ToolChoiceOption.REQUIRED),
+                         Arguments.of(OutputGenerationMode.STRUCTURED_OUTPUT,
+                                      SimpleOpenAIModelOptions.ToolChoice.AUTO,
+                                      ToolChoiceOption.AUTO),
+                         Arguments.of(OutputGenerationMode.STRUCTURED_OUTPUT,
+                                      SimpleOpenAIModelOptions.ToolChoice.DEFAULT,
+                                      ToolChoiceOption.AUTO)
+        );
+    }
+
+    @ParameterizedTest(name = "mode={0}, toolChoice={1} => {2}")
+    @MethodSource("resolveToolChoiceCases")
+    void testResolveToolChoice(OutputGenerationMode mode,
+                               SimpleOpenAIModelOptions.ToolChoice toolChoice,
+                               ToolChoiceOption expected) {
+        assertEquals(expected, OpenAIMessageUtils.resolveToolChoice(mode, toolChoice));
+    }
+}

--- a/sentinel-ai-reporting/pom.xml
+++ b/sentinel-ai-reporting/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.phonepe.sentinel-ai</groupId>
         <artifactId>sentinel-ai</artifactId>
-        <version>1.1.1-alpha7</version>
+        <version>1.1.1-alpha8</version>
     </parent>
 
     <artifactId>sentinel-ai-reporting</artifactId>

--- a/sentinel-ai-session/pom.xml
+++ b/sentinel-ai-session/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.phonepe.sentinel-ai</groupId>
         <artifactId>sentinel-ai</artifactId>
-        <version>1.1.1-alpha7</version>
+        <version>1.1.1-alpha8</version>
     </parent>
 
     <artifactId>sentinel-ai-session</artifactId>

--- a/sentinel-ai-storage-es/pom.xml
+++ b/sentinel-ai-storage-es/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.phonepe.sentinel-ai</groupId>
         <artifactId>sentinel-ai</artifactId>
-        <version>1.1.1-alpha7</version>
+        <version>1.1.1-alpha8</version>
     </parent>
 
     <artifactId>sentinel-ai-storage-es</artifactId>

--- a/sentinel-ai-toolbox-mcp/pom.xml
+++ b/sentinel-ai-toolbox-mcp/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.phonepe.sentinel-ai</groupId>
         <artifactId>sentinel-ai</artifactId>
-        <version>1.1.1-alpha7</version>
+        <version>1.1.1-alpha8</version>
     </parent>
 
     <artifactId>sentinel-ai-toolbox-mcp</artifactId>

--- a/sentinel-ai-toolbox-remote-http/pom.xml
+++ b/sentinel-ai-toolbox-remote-http/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.phonepe.sentinel-ai</groupId>
         <artifactId>sentinel-ai</artifactId>
-        <version>1.1.1-alpha7</version>
+        <version>1.1.1-alpha8</version>
     </parent>
 
     <artifactId>sentinel-ai-toolbox-remote-http</artifactId>


### PR DESCRIPTION
Till now when output generation mode was set to TOOL_BASED, system would force tool_choice to REQUIRED. This is causing issues in some OSS models when served with vllm etc. With the DEFAULT mode, this remains the default behaviour, but users have a choice to set tool call to AUTO.

Have added tests and documentation updates.

Tested with tool based output with kimi 2.6 on vLLM.