### PR TITLE
Support for injecting extra data into session summary

### DIFF
--- a/docs/docs/messages-session.md
+++ b/docs/docs/messages-session.md
@@ -20,6 +20,7 @@ The `AgentSessionExtension` provides automated conversation history persistence 
 - **Context Injection**: Injects the latest session summary as a fact in the system prompt.
 - **Pre-filtering**: Supports filtering messages before persistence (e.g., removing system prompts or failed tool calls).
 - **Message Selection**: Supports selecting specific messages for context (e.g., removing unpaired tool calls).
+- **Extra Data Injection**: Attach custom metadata to every saved `SessionSummary` via `SessionExtraDataOperator`.
 
 ## Tools
 
@@ -67,6 +68,53 @@ final var response = agent.execute(AgentInput.<MyRequest>builder()
                 .build())
         .build());
 ```
+
+## Extra Data Injection
+
+`SessionExtraDataOperator` is a `UnaryOperator<SessionSummary>` that is applied inside `SessionStore.saveSession()` every time a summary is persisted. Use it to attach arbitrary metadata to the `extra` field of `SessionSummary` without touching the summarization logic.
+
+### Built-in factories
+
+| Factory | Behaviour |
+|---|---|
+| `SessionExtraDataOperator.empty()` | No-op; leaves `extra` unchanged (default). |
+| `SessionExtraDataOperator.fixed(map)` | Sets `extra` to a constant `Map<String, Object>` on every save. |
+
+### Custom operator
+
+Subclass `SessionExtraDataOperator` and implement `operate()` to derive the extra data from the summary itself:
+
+```java
+final var operator = new SessionExtraDataOperator() {
+    @Override
+    protected Optional<Map<String, Object>> operate(SessionSummary summary) {
+        return Optional.of(Map.of("tenant", resolveTenant(summary.getSessionId())));
+    }
+};
+```
+
+Returning `Optional.empty()` leaves `extra` unchanged.
+
+### Wiring into the session store
+
+The operator is configured on the `SessionStore` implementation, and called ever time `saveSession` is invoked:
+
+```java
+// Filesystem
+final var sessionStore = FileSystemSessionStore.builder()
+        .baseDir("/path/to/storage")
+        .mapper(objectMapper)
+        .extraDataOperator(SessionExtraDataOperator.fixed(Map.of("region", "us-east-1")))
+        .build();
+
+// Elasticsearch
+final var sessionStore = ESSessionStore.builder()
+        .client(esClient)
+        .mapper(objectMapper)
+        .extraDataOperator(SessionExtraDataOperator.fixed(Map.of("region", "us-east-1")))
+        .build();
+```
+
 
 ## Session Storage Implementations
 

--- a/sentinel-ai-filesystem/src/main/java/com/phonepe/sentinelai/filesystem/session/FileSystemSessionStore.java
+++ b/sentinel-ai-filesystem/src/main/java/com/phonepe/sentinelai/filesystem/session/FileSystemSessionStore.java
@@ -22,26 +22,36 @@ import com.phonepe.sentinelai.core.agentmessages.AgentMessage;
 import com.phonepe.sentinelai.session.BiScrollable;
 import com.phonepe.sentinelai.session.BiScrollable.DataPointer;
 import com.phonepe.sentinelai.session.QueryDirection;
+import com.phonepe.sentinelai.session.SessionExtraDataOperator;
 import com.phonepe.sentinelai.session.SessionStore;
 import com.phonepe.sentinelai.session.SessionSummary;
 
+import lombok.Builder;
+import lombok.NonNull;
 import lombok.SneakyThrows;
 
 import java.util.Base64;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
-public class FileSystemSessionStore implements SessionStore {
+import javax.annotation.Nullable;
+
+public class FileSystemSessionStore extends SessionStore {
+    private static final int DEFAULT_CACHE_SIZE = 20;
+
     private final DiskBasedSessionSummaryStore summaryStore;
     private final ObjectMapper mapper;
 
-    public FileSystemSessionStore(String baseDir, final ObjectMapper mapper) {
-        this(baseDir, mapper, 20);
-    }
-
-    public FileSystemSessionStore(String baseDir, final ObjectMapper mapper, int cacheSize) {
-        this.summaryStore = new DiskBasedSessionSummaryStore(baseDir, mapper, cacheSize);
+    @Builder
+    public FileSystemSessionStore(String baseDir,
+                                  @NonNull final ObjectMapper mapper,
+                                  @Nullable Integer cacheSize,
+                                  @Nullable SessionExtraDataOperator extraDataOperator) {
+        super(extraDataOperator);
+        final var size = Objects.requireNonNullElse(cacheSize, DEFAULT_CACHE_SIZE);
+        this.summaryStore = new DiskBasedSessionSummaryStore(baseDir, mapper, size);
         this.mapper = mapper;
     }
 
@@ -66,13 +76,6 @@ public class FileSystemSessionStore implements SessionStore {
         summaryStore.getMessageStorage(sessionId)
                 .orElseThrow(() -> new IllegalStateException("Message storage not found for session: " + sessionId))
                 .addMessages(messages);
-    }
-
-    @Override
-    @SneakyThrows
-    public Optional<SessionSummary> saveSession(SessionSummary sessionSummary) {
-        summaryStore.saveSummary(sessionSummary);
-        return Optional.of(sessionSummary);
     }
 
     @Override
@@ -143,6 +146,13 @@ public class FileSystemSessionStore implements SessionStore {
         final var newer = queryDirection == QueryDirection.NEWER ? newestResultPtr : updatedNewerForOlderQuery;
 
         return new BiScrollable<>(filteredSummaries, new DataPointer(older, newer));
+    }
+
+    @Override
+    @SneakyThrows
+    protected Optional<SessionSummary> saveSessionImpl(SessionSummary sessionSummary) {
+        summaryStore.saveSummary(sessionSummary);
+        return Optional.of(sessionSummary);
     }
 
 

--- a/sentinel-ai-filesystem/src/test/java/com/phonepe/sentinelai/filesystem/AgentIntegrationTest.java
+++ b/sentinel-ai-filesystem/src/test/java/com/phonepe/sentinelai/filesystem/AgentIntegrationTest.java
@@ -190,8 +190,10 @@ class AgentIntegrationTest {
         final var memoryStorage = new FileSystemAgentMemoryStorage(new File(tempDir, "memory").getAbsolutePath(),
                                                                    objectMapper,
                                                                    new HuggingfaceEmbeddingModel());
-        final var sessionStorage = new FileSystemSessionStore(new File(tempDir, "session").getAbsolutePath(),
-                                                              objectMapper);
+        final var sessionStorage = FileSystemSessionStore.builder()
+                .baseDir(new File(tempDir, "session").getAbsolutePath())
+                .mapper(objectMapper)
+                .build();
         final var agentSessionExtension = AgentSessionExtension
                 .<UserInput, OutputObject, SimpleAgent>builder()
                 .sessionStore(sessionStorage)

--- a/sentinel-ai-filesystem/src/test/java/com/phonepe/sentinelai/filesystem/session/FileSystemSessionStoreTest.java
+++ b/sentinel-ai-filesystem/src/test/java/com/phonepe/sentinelai/filesystem/session/FileSystemSessionStoreTest.java
@@ -59,19 +59,9 @@ class FileSystemSessionStoreTest {
     private ObjectMapper objectMapper;
     private FileSystemSessionStore sessionStore;
 
-    @BeforeEach
-    void setUp() {
-        objectMapper = JsonUtils.createMapper();
-        sessionStore = FileSystemSessionStore.builder()
-                .baseDir(tempDir.toString())
-                .mapper(objectMapper)
-                .extraDataOperator(SessionExtraDataOperator.fixed(Map.of("testKey", "testValue")))
-                .build();
-    }
-
     @Test
     @SneakyThrows
-    void testBoundedCaching() {
+    void boundedCaching() {
         // Create a store with a small cache size
         final var cacheSize = 5;
         final var boundedStore = FileSystemSessionStore.builder()
@@ -110,6 +100,124 @@ class FileSystemSessionStoreTest {
             final var messages = boundedStore.readMessages(id, 1, false, null, QueryDirection.OLDER);
             assertFalse(messages.getItems().isEmpty());
         }
+    }
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = JsonUtils.createMapper();
+        sessionStore = FileSystemSessionStore.builder()
+                .baseDir(tempDir.toString())
+                .mapper(objectMapper)
+                .extraDataOperator(SessionExtraDataOperator.fixed(Map.of("testKey", "testValue")))
+                .build();
+    }
+
+    @Test
+    void testBuilderAllParameters() {
+        final var extraData = Map.<String, Object>of("key1", "value1", "key2", "value2");
+        final var operator = SessionExtraDataOperator.fixed(extraData);
+        final var cacheSize = 15;
+
+        final var store = FileSystemSessionStore.builder()
+                .baseDir(tempDir.toString())
+                .mapper(objectMapper)
+                .cacheSize(cacheSize)
+                .extraDataOperator(operator)
+                .build();
+
+        assertNotNull(store);
+        final var sessionSummary = SessionSummary.builder()
+                .sessionId("test-3")
+                .title("Test")
+                .summary("Summary")
+                .updatedAt(System.currentTimeMillis())
+                .build();
+
+        final var result = store.saveSession(sessionSummary);
+        assertTrue(result.isPresent());
+        assertEquals(extraData, result.get().getExtra());
+    }
+
+    @Test
+    void testBuilderWithCacheSize() {
+        final var customCacheSize = 10;
+        final var store = FileSystemSessionStore.builder()
+                .baseDir(tempDir.toString())
+                .mapper(objectMapper)
+                .cacheSize(customCacheSize)
+                .build();
+
+        assertNotNull(store);
+        assertFalse(store.deleteSession("non-existent"));
+    }
+
+    @Test
+    void testBuilderWithDefaults() {
+        final var store = FileSystemSessionStore.builder()
+                .baseDir(tempDir.toString())
+                .mapper(objectMapper)
+                .build();
+
+        assertNotNull(store);
+        final var sessionSummary = SessionSummary.builder()
+                .sessionId("test-1")
+                .title("Test")
+                .summary("Summary")
+                .updatedAt(System.currentTimeMillis())
+                .build();
+
+        final var result = store.saveSession(sessionSummary);
+        assertTrue(result.isPresent());
+        assertTrue(result.get().getExtra().isEmpty());
+    }
+
+    @Test
+    void testBuilderWithExtraDataOperator() {
+        final var extraData = Map.<String, Object>of("custom", "data");
+        final var operator = SessionExtraDataOperator.fixed(extraData);
+        final var store = FileSystemSessionStore.builder()
+                .baseDir(tempDir.toString())
+                .mapper(objectMapper)
+                .extraDataOperator(operator)
+                .build();
+
+        assertNotNull(store);
+        final var sessionSummary = SessionSummary.builder()
+                .sessionId("test-2")
+                .title("Test")
+                .summary("Summary")
+                .updatedAt(System.currentTimeMillis())
+                .build();
+
+        final var result = store.saveSession(sessionSummary);
+        assertTrue(result.isPresent());
+        assertEquals(extraData, result.get().getExtra());
+    }
+
+    @Test
+    @SneakyThrows
+    void testExtraDataPersistence() {
+        final var extraData = Map.<String, Object>of("persisted", "value", "timestamp", 123456L);
+        final var operator = SessionExtraDataOperator.fixed(extraData);
+        final var store = FileSystemSessionStore.builder()
+                .baseDir(tempDir.toString())
+                .mapper(objectMapper)
+                .extraDataOperator(operator)
+                .build();
+
+        final var sessionId = "persistence-test";
+        final var sessionSummary = SessionSummary.builder()
+                .sessionId(sessionId)
+                .title("Persistence Test")
+                .summary("Testing extra data persistence")
+                .updatedAt(AgentUtils.epochMicro())
+                .build();
+
+        store.saveSession(sessionSummary);
+        final var retrieved = store.session(sessionId);
+
+        assertTrue(retrieved.isPresent());
+        assertEquals(extraData, retrieved.get().getExtra());
     }
 
     @Test
@@ -276,4 +384,5 @@ class FileSystemSessionStoreTest {
         assertEquals("S-4", response.getItems().get(0).getSessionId());
         assertEquals("S-1", response.getItems().get(3).getSessionId());
     }
+
 }

--- a/sentinel-ai-filesystem/src/test/java/com/phonepe/sentinelai/filesystem/session/FileSystemSessionStoreTest.java
+++ b/sentinel-ai-filesystem/src/test/java/com/phonepe/sentinelai/filesystem/session/FileSystemSessionStoreTest.java
@@ -32,6 +32,7 @@ import com.phonepe.sentinelai.core.utils.AgentUtils;
 import com.phonepe.sentinelai.core.utils.JsonUtils;
 import com.phonepe.sentinelai.session.BiScrollable;
 import com.phonepe.sentinelai.session.QueryDirection;
+import com.phonepe.sentinelai.session.SessionExtraDataOperator;
 import com.phonepe.sentinelai.session.SessionSummary;
 
 import lombok.SneakyThrows;
@@ -39,10 +40,12 @@ import lombok.SneakyThrows;
 import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -59,7 +62,11 @@ class FileSystemSessionStoreTest {
     @BeforeEach
     void setUp() {
         objectMapper = JsonUtils.createMapper();
-        sessionStore = new FileSystemSessionStore(tempDir.toString(), objectMapper);
+        sessionStore = FileSystemSessionStore.builder()
+                .baseDir(tempDir.toString())
+                .mapper(objectMapper)
+                .extraDataOperator(SessionExtraDataOperator.fixed(Map.of("testKey", "testValue")))
+                .build();
     }
 
     @Test
@@ -67,10 +74,11 @@ class FileSystemSessionStoreTest {
     void testBoundedCaching() {
         // Create a store with a small cache size
         final var cacheSize = 5;
-        final var boundedStore = new FileSystemSessionStore(tempDir.resolve("bounded").toString(),
-                                                            objectMapper,
-                                                            cacheSize);
-
+        final var boundedStore = FileSystemSessionStore.builder()
+                .baseDir(tempDir.toString())
+                .mapper(objectMapper)
+                .cacheSize(cacheSize)
+                .build();
         // Save more sessions than the cache size
         final var sessionIds = IntStream.rangeClosed(1, 10)
                 .mapToObj(i -> {
@@ -200,6 +208,11 @@ class FileSystemSessionStoreTest {
         assertEquals(1, sessions.getItems().size());
         assertEquals(sessionId, sessions.getItems().get(0).getSessionId());
 
+        assertAll(() -> {
+            final var testSession = sessionStore.session(sessionId).get();
+            assertNotNull(testSession);
+            assertEquals("testValue", testSession.getExtra().get("testKey"));
+        });
         assertTrue(sessionStore.deleteSession(sessionId));
         assertFalse(sessionStore.session(sessionId).isPresent());
     }

--- a/sentinel-ai-session/src/main/java/com/phonepe/sentinelai/session/AgentSessionExtension.java
+++ b/sentinel-ai-session/src/main/java/com/phonepe/sentinelai/session/AgentSessionExtension.java
@@ -63,6 +63,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutionException;
 
+import javax.annotation.Nullable;
+
 import static com.phonepe.sentinelai.session.MessageReadingUtils.readMessagesSinceId;
 import static com.phonepe.sentinelai.session.MessageReadingUtils.rearrangeMessages;
 
@@ -82,6 +84,7 @@ public class AgentSessionExtension<R, T, A extends Agent<R, T, A>> implements Ag
     private final AgentSessionExtensionSetup setup;
     private final List<MessagePersistencePreFilter> historyModifiers;
     private final List<MessageSelector> messageSelectors;
+    private final SessionExtraDataOperator extraDataOperator;
     private final AgentEventMessageExtractor extractor = new AgentEventMessageExtractor();
     private final ConsumingFireForgetSignal<SessionSummary> onSessionSummarized = new ConsumingFireForgetSignal<>();
     private A agent;
@@ -99,7 +102,8 @@ public class AgentSessionExtension<R, T, A extends Agent<R, T, A>> implements Ag
                                  @NonNull SessionStore sessionStore,
                                  AgentSessionExtensionSetup setup,
                                  List<MessagePersistencePreFilter> historyModifiers,
-                                 List<MessageSelector> messageSelectors) {
+                                 List<MessageSelector> messageSelectors,
+                                 @Nullable SessionExtraDataOperator extraDataOperator) {
         this.mapper = Objects.requireNonNullElseGet(mapper,
                                                     JsonUtils::createMapper);
         this.setup = Objects.requireNonNullElse(setup,
@@ -114,6 +118,8 @@ public class AgentSessionExtension<R, T, A extends Agent<R, T, A>> implements Ag
                 .requireNonNullElseGet(messageSelectors,
                                        () -> List.of(
                                                      new UnpairedToolCallsRemover())));
+        this.extraDataOperator = Objects.requireNonNullElseGet(extraDataOperator,
+                                                               SessionExtraDataOperator::empty);
     }
 
     public AgentSessionExtension<R, T, A> addMessagePersistencePreFilter(MessagePersistencePreFilter modifier) {
@@ -371,7 +377,7 @@ public class AgentSessionExtension<R, T, A extends Agent<R, T, A>> implements Ag
                                   lastSummarizedMessageId,
                                   sessionId);
 
-                        final var updated = sessionStore.saveSession(SessionSummary
+                        final var sessionSummary = SessionSummary
                                 .builder()
                                 .sessionId(sessionId)
                                 .title(summary.getTitle())
@@ -380,7 +386,8 @@ public class AgentSessionExtension<R, T, A extends Agent<R, T, A>> implements Ag
                                 .raw(summary.getRaw())
                                 .lastSummarizedMessageId(lastSummarizedMessageId)
                                 .updatedAt(AgentUtils.epochMicro())
-                                .build());
+                                .build();
+                        final var updated = sessionStore.saveSession(extraDataOperator.apply(sessionSummary));
                         updated.ifPresentOrElse(
                                                 savedSummary -> log.info(
                                                                          "Summary saved successfully for session: {}. Title: {}",
@@ -465,7 +472,7 @@ public class AgentSessionExtension<R, T, A extends Agent<R, T, A>> implements Ag
         }
         else {
             log.debug("Session summary extracted: {}", summary);
-            final var updated = sessionStore.saveSession(SessionSummary
+            final var sessionSummary = SessionSummary
                     .builder()
                     .sessionId(sessionId)
                     .title(summary.getTitle())
@@ -474,7 +481,8 @@ public class AgentSessionExtension<R, T, A extends Agent<R, T, A>> implements Ag
                     .raw(mapper.writeValueAsString(summary.getRawData()))
                     .lastSummarizedMessageId(lastSummarizedMessageId)
                     .updatedAt(AgentUtils.epochMicro())
-                    .build());
+                    .build();
+            final var updated = sessionStore.saveSession(sessionSummary);
             updated.ifPresentOrElse(
                                     savedSummary -> {
                                         log.info("Summary saved successfully for session: {}. Title: {}",

--- a/sentinel-ai-session/src/main/java/com/phonepe/sentinelai/session/AgentSessionExtension.java
+++ b/sentinel-ai-session/src/main/java/com/phonepe/sentinelai/session/AgentSessionExtension.java
@@ -63,8 +63,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutionException;
 
-import javax.annotation.Nullable;
-
 import static com.phonepe.sentinelai.session.MessageReadingUtils.readMessagesSinceId;
 import static com.phonepe.sentinelai.session.MessageReadingUtils.rearrangeMessages;
 
@@ -84,7 +82,6 @@ public class AgentSessionExtension<R, T, A extends Agent<R, T, A>> implements Ag
     private final AgentSessionExtensionSetup setup;
     private final List<MessagePersistencePreFilter> historyModifiers;
     private final List<MessageSelector> messageSelectors;
-    private final SessionExtraDataOperator extraDataOperator;
     private final AgentEventMessageExtractor extractor = new AgentEventMessageExtractor();
     private final ConsumingFireForgetSignal<SessionSummary> onSessionSummarized = new ConsumingFireForgetSignal<>();
     private A agent;
@@ -102,8 +99,7 @@ public class AgentSessionExtension<R, T, A extends Agent<R, T, A>> implements Ag
                                  @NonNull SessionStore sessionStore,
                                  AgentSessionExtensionSetup setup,
                                  List<MessagePersistencePreFilter> historyModifiers,
-                                 List<MessageSelector> messageSelectors,
-                                 @Nullable SessionExtraDataOperator extraDataOperator) {
+                                 List<MessageSelector> messageSelectors) {
         this.mapper = Objects.requireNonNullElseGet(mapper,
                                                     JsonUtils::createMapper);
         this.setup = Objects.requireNonNullElse(setup,
@@ -118,8 +114,6 @@ public class AgentSessionExtension<R, T, A extends Agent<R, T, A>> implements Ag
                 .requireNonNullElseGet(messageSelectors,
                                        () -> List.of(
                                                      new UnpairedToolCallsRemover())));
-        this.extraDataOperator = Objects.requireNonNullElseGet(extraDataOperator,
-                                                               SessionExtraDataOperator::empty);
     }
 
     public AgentSessionExtension<R, T, A> addMessagePersistencePreFilter(MessagePersistencePreFilter modifier) {
@@ -377,7 +371,7 @@ public class AgentSessionExtension<R, T, A extends Agent<R, T, A>> implements Ag
                                   lastSummarizedMessageId,
                                   sessionId);
 
-                        final var sessionSummary = SessionSummary
+                        final var updated = sessionStore.saveSession(SessionSummary
                                 .builder()
                                 .sessionId(sessionId)
                                 .title(summary.getTitle())
@@ -386,8 +380,7 @@ public class AgentSessionExtension<R, T, A extends Agent<R, T, A>> implements Ag
                                 .raw(summary.getRaw())
                                 .lastSummarizedMessageId(lastSummarizedMessageId)
                                 .updatedAt(AgentUtils.epochMicro())
-                                .build();
-                        final var updated = sessionStore.saveSession(extraDataOperator.apply(sessionSummary));
+                                .build());
                         updated.ifPresentOrElse(
                                                 savedSummary -> log.info(
                                                                          "Summary saved successfully for session: {}. Title: {}",
@@ -472,7 +465,7 @@ public class AgentSessionExtension<R, T, A extends Agent<R, T, A>> implements Ag
         }
         else {
             log.debug("Session summary extracted: {}", summary);
-            final var sessionSummary = SessionSummary
+            final var updated = sessionStore.saveSession(SessionSummary
                     .builder()
                     .sessionId(sessionId)
                     .title(summary.getTitle())
@@ -481,8 +474,7 @@ public class AgentSessionExtension<R, T, A extends Agent<R, T, A>> implements Ag
                     .raw(mapper.writeValueAsString(summary.getRawData()))
                     .lastSummarizedMessageId(lastSummarizedMessageId)
                     .updatedAt(AgentUtils.epochMicro())
-                    .build();
-            final var updated = sessionStore.saveSession(sessionSummary);
+                    .build());
             updated.ifPresentOrElse(
                                     savedSummary -> {
                                         log.info("Summary saved successfully for session: {}. Title: {}",

--- a/sentinel-ai-session/src/main/java/com/phonepe/sentinelai/session/SessionExtraDataOperator.java
+++ b/sentinel-ai-session/src/main/java/com/phonepe/sentinelai/session/SessionExtraDataOperator.java
@@ -20,8 +20,15 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.UnaryOperator;
 
+/**
+ * A {@link UnaryOperator} that can be used to add extra data to a {@link SessionSummary}.
+ */
 public abstract class SessionExtraDataOperator implements UnaryOperator<SessionSummary> {
 
+    /**
+     * A no-op implementation of {@link SessionExtraDataOperator} that returns an empty optional,
+     * indicating that no extra data should be added to the session summary.
+     */
     public static final class NoOp extends SessionExtraDataOperator {
         @Override
         protected Optional<Map<String, Object>> operate(SessionSummary sessionSummary) {
@@ -29,17 +36,44 @@ public abstract class SessionExtraDataOperator implements UnaryOperator<SessionS
         }
     }
 
+    /**
+     * A fixed implementation of {@link SessionExtraDataOperator} that always returns the same extra data,
+     * regardless of the input session summary.
+     * This will make a copy of the input map once to ensure immutability and thread-safety.
+     */
+    public static final class Fixed extends SessionExtraDataOperator {
+        private final Map<String, Object> extra;
+
+        public Fixed(Map<String, Object> extra) {
+            this.extra = Map.copyOf(extra);
+        }
+
+        @Override
+        protected Optional<Map<String, Object>> operate(SessionSummary sessionSummary) {
+            return Optional.of(extra);
+        }
+    }
+
+    /**
+     * Creates a new instance of {@link SessionExtraDataOperator} that does not add any extra data to the session
+     * summary.
+     *
+     * @return a new instance of {@link SessionExtraDataOperator} that does not add any extra data to the session
+     *         summary
+     */
     public static SessionExtraDataOperator empty() {
         return new NoOp();
     }
 
+    /**
+     * Creates a new instance of {@link SessionExtraDataOperator} that always returns the same extra data,
+     * regardless of the input session summary.
+     *
+     * @param extra the extra data to be added to the session summary
+     * @return a new instance of {@link SessionExtraDataOperator} that always returns the same extra data
+     */
     public static SessionExtraDataOperator fixed(Map<String, Object> extra) {
-        return new SessionExtraDataOperator() {
-            @Override
-            protected Optional<Map<String, Object>> operate(SessionSummary sessionSummary) {
-                return Optional.of(extra);
-            }
-        };
+        return new Fixed(extra);
     }
 
     @Override
@@ -51,5 +85,16 @@ public abstract class SessionExtraDataOperator implements UnaryOperator<SessionS
         return sessionSummary;
     }
 
+    /**
+     * Operates on the given session summary and returns an optional map of extra data to be added to the session
+     * summary.
+     *
+     * Implementations of this method can choose to return an empty optional if no extra data should be added to
+     * the session summary, or a non-empty optional if extra data should be added to the session summary.
+     * Implementers need to be aware of the fact that this is called on every call of SessionSummary.saveSession()
+     * 
+     * @param sessionSummary the session summary to operate on
+     * @return an optional map of extra data to be added to the session summary
+     */
     protected abstract Optional<Map<String, Object>> operate(final SessionSummary sessionSummary);
 }

--- a/sentinel-ai-session/src/main/java/com/phonepe/sentinelai/session/SessionExtraDataOperator.java
+++ b/sentinel-ai-session/src/main/java/com/phonepe/sentinelai/session/SessionExtraDataOperator.java
@@ -26,17 +26,6 @@ import java.util.function.UnaryOperator;
 public abstract class SessionExtraDataOperator implements UnaryOperator<SessionSummary> {
 
     /**
-     * A no-op implementation of {@link SessionExtraDataOperator} that returns an empty optional,
-     * indicating that no extra data should be added to the session summary.
-     */
-    public static final class NoOp extends SessionExtraDataOperator {
-        @Override
-        protected Optional<Map<String, Object>> operate(SessionSummary sessionSummary) {
-            return Optional.empty();
-        }
-    }
-
-    /**
      * A fixed implementation of {@link SessionExtraDataOperator} that always returns the same extra data,
      * regardless of the input session summary.
      * This will make a copy of the input map once to ensure immutability and thread-safety.
@@ -51,6 +40,17 @@ public abstract class SessionExtraDataOperator implements UnaryOperator<SessionS
         @Override
         protected Optional<Map<String, Object>> operate(SessionSummary sessionSummary) {
             return Optional.of(extra);
+        }
+    }
+
+    /**
+     * A no-op implementation of {@link SessionExtraDataOperator} that returns an empty optional,
+     * indicating that no extra data should be added to the session summary.
+     */
+    public static final class NoOp extends SessionExtraDataOperator {
+        @Override
+        protected Optional<Map<String, Object>> operate(SessionSummary sessionSummary) {
+            return Optional.empty();
         }
     }
 
@@ -92,7 +92,7 @@ public abstract class SessionExtraDataOperator implements UnaryOperator<SessionS
      * Implementations of this method can choose to return an empty optional if no extra data should be added to
      * the session summary, or a non-empty optional if extra data should be added to the session summary.
      * Implementers need to be aware of the fact that this is called on every call of SessionSummary.saveSession()
-     * 
+     *
      * @param sessionSummary the session summary to operate on
      * @return an optional map of extra data to be added to the session summary
      */

--- a/sentinel-ai-session/src/main/java/com/phonepe/sentinelai/session/SessionExtraDataOperator.java
+++ b/sentinel-ai-session/src/main/java/com/phonepe/sentinelai/session/SessionExtraDataOperator.java
@@ -51,5 +51,5 @@ public abstract class SessionExtraDataOperator implements UnaryOperator<SessionS
         return sessionSummary;
     }
 
-    abstract protected Optional<Map<String, Object>> operate(final SessionSummary sessionSummary);
+    protected abstract Optional<Map<String, Object>> operate(final SessionSummary sessionSummary);
 }

--- a/sentinel-ai-session/src/main/java/com/phonepe/sentinelai/session/SessionExtraDataOperator.java
+++ b/sentinel-ai-session/src/main/java/com/phonepe/sentinelai/session/SessionExtraDataOperator.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2025 Original Author(s), PhonePe India Pvt. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.phonepe.sentinelai.session;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.UnaryOperator;
+
+public abstract class SessionExtraDataOperator implements UnaryOperator<SessionSummary> {
+
+    public static final class NoOp extends SessionExtraDataOperator {
+        @Override
+        protected Optional<Map<String, Object>> operate(SessionSummary sessionSummary) {
+            return Optional.empty();
+        }
+    }
+
+    public static SessionExtraDataOperator empty() {
+        return new NoOp();
+    }
+
+    public static SessionExtraDataOperator fixed(Map<String, Object> extra) {
+        return new SessionExtraDataOperator() {
+            @Override
+            protected Optional<Map<String, Object>> operate(SessionSummary sessionSummary) {
+                return Optional.of(extra);
+            }
+        };
+    }
+
+    @Override
+    public SessionSummary apply(SessionSummary sessionSummary) {
+        final var extra = operate(sessionSummary).orElse(null);
+        if (extra != null) {
+            return sessionSummary.withExtra(extra);
+        }
+        return sessionSummary;
+    }
+
+    abstract Optional<Map<String, Object>> operate(final SessionSummary sessionSummary);
+}

--- a/sentinel-ai-session/src/main/java/com/phonepe/sentinelai/session/SessionExtraDataOperator.java
+++ b/sentinel-ai-session/src/main/java/com/phonepe/sentinelai/session/SessionExtraDataOperator.java
@@ -51,5 +51,5 @@ public abstract class SessionExtraDataOperator implements UnaryOperator<SessionS
         return sessionSummary;
     }
 
-    abstract Optional<Map<String, Object>> operate(final SessionSummary sessionSummary);
+    abstract protected Optional<Map<String, Object>> operate(final SessionSummary sessionSummary);
 }

--- a/sentinel-ai-session/src/main/java/com/phonepe/sentinelai/session/SessionStore.java
+++ b/sentinel-ai-session/src/main/java/com/phonepe/sentinelai/session/SessionStore.java
@@ -19,13 +19,29 @@ package com.phonepe.sentinelai.session;
 import com.phonepe.sentinelai.core.agentmessages.AgentMessage;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
+
+import javax.annotation.Nullable;
 
 /**
  * A storage system for agent session
  */
-public interface SessionStore {
-    boolean deleteSession(String sessionId);
+public abstract class SessionStore {
+
+    private final SessionExtraDataOperator extraDataOperator;
+
+    protected SessionStore(@Nullable SessionExtraDataOperator extraDataOperator) {
+        this.extraDataOperator = Objects.requireNonNullElse(extraDataOperator, SessionExtraDataOperator.empty());
+    }
+
+    /**
+     * Deletes a session and all its associated data.
+     *
+     * @param sessionId The unique identifier for the session to delete.
+     * @return true if the session was successfully deleted, false otherwise.
+     */
+    public abstract boolean deleteSession(String sessionId);
 
     /**
      * Reads messages for a specific session with pagination support.
@@ -44,22 +60,66 @@ public interface SessionStore {
      * @return A {@link BiScrollable} containing the list of messages (sorted chronologically) and pointers for
      *         further scrolling.
      */
-    BiScrollable<AgentMessage> readMessages(String sessionId,
-                                            int count,
-                                            boolean skipSystemPrompt,
-                                            BiScrollable.DataPointer pointer,
-                                            QueryDirection queryDirection);
+    public abstract BiScrollable<AgentMessage> readMessages(String sessionId,
+                                                            int count,
+                                                            boolean skipSystemPrompt,
+                                                            BiScrollable.DataPointer pointer,
+                                                            QueryDirection queryDirection);
 
-    void saveMessages(String sessionId,
-                      String runId,
-                      List<AgentMessage> messages);
+    /**
+     * Saves a list of messages for a specific session and run. The session will be created if it doesn't exist.
+     *
+     * @param sessionId The unique identifier for the session.
+     * @param runId     The unique identifier for the run within the session.
+     * @param messages  The list of messages to save, in chronological order (oldest to newest).
+     */
+    public abstract void saveMessages(String sessionId,
+                                      String runId,
+                                      List<AgentMessage> messages);
 
-    Optional<SessionSummary> saveSession(SessionSummary sessionSummary);
+    /**
+     * Saves the session summary.
+     * The session summary will be created if it doesn't exist.
+     *
+     * @param sessionSummary The session summary to save.
+     * @return The saved session summary, or empty if the save operation failed.
+     */
+    public final Optional<SessionSummary> saveSession(SessionSummary sessionSummary) {
+        return saveSessionImpl(extraDataOperator.apply(sessionSummary));
+    }
 
-    Optional<SessionSummary> session(String sessionId);
+    /**
+     * Retrieves the session summary for a specific session.
+     *
+     * @param sessionId The unique identifier for the session.
+     * @return An Optional containing the session summary if found, or empty if not found.
+     */
+    public abstract Optional<SessionSummary> session(String sessionId);
 
-    BiScrollable<SessionSummary> sessions(int count,
-                                          String pointer,
-                                          QueryDirection queryDirection);
+    /**
+     * Lists session summaries with pagination support. The sessions are returned in reverse chronological order
+     * (newest to oldest).
+     *
+     * @param count          The maximum number of session summaries to retrieve.
+     * @param pointer        The {@link com.phonepe.sentinelai.session.BiScrollable.DataPointer} used by the client
+     *                       to indicate the current position in the session list.
+     * @param queryDirection The direction to scroll in: {@link QueryDirection#OLDER} to fetch sessions before the
+     *                       pointer,
+     *                       or {@link QueryDirection#NEWER} to fetch sessions after the pointer.
+     * @return A {@link BiScrollable} containing the list of session summaries (sorted reverse chronologically)
+     *         and pointers for further scrolling.
+     */
+    public abstract BiScrollable<SessionSummary> sessions(int count,
+                                                          String pointer,
+                                                          QueryDirection queryDirection);
+
+    /**
+     * Implementation method for saving the session summary.
+     * The session summary will be created if it doesn't exist.
+     *
+     * @param sessionSummary The session summary to save, with extra data applied.
+     * @return The saved session summary, or empty if the save operation failed.
+     */
+    protected abstract Optional<SessionSummary> saveSessionImpl(SessionSummary sessionSummary);
 
 }

--- a/sentinel-ai-session/src/main/java/com/phonepe/sentinelai/session/SessionSummary.java
+++ b/sentinel-ai-session/src/main/java/com/phonepe/sentinelai/session/SessionSummary.java
@@ -21,8 +21,10 @@ import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 
 import lombok.Builder;
 import lombok.Value;
+import lombok.With;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * A summary for the session
@@ -48,5 +50,11 @@ public class SessionSummary {
     @JsonPropertyDescription("Structured data extracted from the conversation")
     String raw;
 
+    @JsonPropertyDescription("Any extra information that might be useful for the client")
+    @With
+    @Builder.Default
+    Map<String, Object> extra = Map.of();
+
+    @With
     long updatedAt;
 }

--- a/sentinel-ai-session/src/test/java/com/phonepe/sentinelai/session/AgentSessionExtensionTest.java
+++ b/sentinel-ai-session/src/test/java/com/phonepe/sentinelai/session/AgentSessionExtensionTest.java
@@ -124,10 +124,14 @@ class AgentSessionExtensionTest {
         }
     }
 
-    private static final class InMemorySessionStore implements SessionStore {
+    private static final class InMemorySessionStore extends SessionStore {
 
         private final Map<String, SessionSummary> sessionData = new ConcurrentHashMap<>();
         private final Map<String, List<AgentMessage>> messageData = new ConcurrentHashMap<>();
+
+        public InMemorySessionStore() {
+            super(SessionExtraDataOperator.empty());
+        }
 
         @Override
         public boolean deleteSession(String sessionId) {
@@ -158,12 +162,6 @@ class AgentSessionExtensionTest {
         }
 
         @Override
-        public Optional<SessionSummary> saveSession(SessionSummary sessionSummary) {
-            sessionData.put(sessionSummary.getSessionId(), sessionSummary);
-            return session(sessionSummary.getSessionId());
-        }
-
-        @Override
         public Optional<SessionSummary> session(String sessionId) {
             return Optional.ofNullable(sessionData.get(sessionId));
         }
@@ -174,6 +172,12 @@ class AgentSessionExtensionTest {
                                                      QueryDirection queryDirection) {
             return new BiScrollable<>(List.copyOf(sessionData.values()),
                                       new BiScrollable.DataPointer(null, null));
+        }
+
+        @Override
+        protected Optional<SessionSummary> saveSessionImpl(SessionSummary sessionSummary) {
+            sessionData.put(sessionSummary.getSessionId(), sessionSummary);
+            return session(sessionSummary.getSessionId());
         }
 
     }
@@ -534,7 +538,7 @@ class AgentSessionExtensionTest {
                 .build();
 
         // Save a session first
-        sessionStore.saveSession(SessionSummary.builder()
+        sessionStore.saveSessionImpl(SessionSummary.builder()
                 .sessionId("existing-session")
                 .title("Test Session")
                 .summary("This is a test summary")

--- a/sentinel-ai-session/src/test/java/com/phonepe/sentinelai/session/MessageReadingUtilsTest.java
+++ b/sentinel-ai-session/src/test/java/com/phonepe/sentinelai/session/MessageReadingUtilsTest.java
@@ -39,8 +39,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class MessageReadingUtilsTest {
 
-    private static final class InMemorySessionStore implements SessionStore {
+    private static final class InMemorySessionStore extends SessionStore {
         private final Map<String, List<AgentMessage>> messageData = new ConcurrentHashMap<>();
+
+        public InMemorySessionStore() {
+            super(SessionExtraDataOperator.empty());
+        }
 
         @Override
         public boolean deleteSession(final String sessionId) {
@@ -122,11 +126,6 @@ class MessageReadingUtilsTest {
         }
 
         @Override
-        public Optional<SessionSummary> saveSession(final SessionSummary sessionSummary) {
-            return Optional.empty();
-        }
-
-        @Override
         public Optional<SessionSummary> session(final String sessionId) {
             return Optional.empty();
         }
@@ -137,6 +136,12 @@ class MessageReadingUtilsTest {
                                                      final QueryDirection queryDirection) {
             return null;
         }
+
+        @Override
+        protected Optional<SessionSummary> saveSessionImpl(final SessionSummary sessionSummary) {
+            return Optional.empty();
+        }
+
     }
 
     private InMemorySessionStore sessionStore;

--- a/sentinel-ai-session/src/test/java/com/phonepe/sentinelai/session/SessionExtraDataOperatorTest.java
+++ b/sentinel-ai-session/src/test/java/com/phonepe/sentinelai/session/SessionExtraDataOperatorTest.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright (c) 2025 Original Author(s), PhonePe India Pvt. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.phonepe.sentinelai.session;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SessionExtraDataOperatorTest {
+
+    @Test
+    void testCustomOperator() {
+        final var operator = new SessionExtraDataOperator() {
+            @Override
+            protected Optional<Map<String, Object>> operate(SessionSummary sessionSummary) {
+                if (sessionSummary.getSessionId().startsWith("special-")) {
+                    return Optional.of(Map.of("type", "special"));
+                }
+                return Optional.empty();
+            }
+        };
+
+        final var specialSession = SessionSummary.builder()
+                .sessionId("special-123")
+                .title("Test")
+                .summary("Summary")
+                .updatedAt(System.currentTimeMillis())
+                .build();
+
+        final var resultSpecial = operator.apply(specialSession);
+        assertEquals("special", resultSpecial.getExtra().get("type"));
+
+        final var normalSession = SessionSummary.builder()
+                .sessionId("normal-123")
+                .title("Test")
+                .summary("Summary")
+                .updatedAt(System.currentTimeMillis())
+                .build();
+
+        final var resultNormal = operator.apply(normalSession);
+        assertTrue(resultNormal.getExtra().isEmpty());
+    }
+
+    @Test
+    void testEmptyOperatorMultipleInvocations() {
+        final var operator = SessionExtraDataOperator.empty();
+        final var sessionSummary = SessionSummary.builder()
+                .sessionId("s1")
+                .title("Test")
+                .summary("Summary")
+                .updatedAt(System.currentTimeMillis())
+                .build();
+
+        final var result1 = operator.apply(sessionSummary);
+        final var result2 = operator.apply(result1);
+        final var result3 = operator.apply(result2);
+
+        assertTrue(result1.getExtra().isEmpty());
+        assertTrue(result2.getExtra().isEmpty());
+        assertTrue(result3.getExtra().isEmpty());
+    }
+
+    @Test
+    void testEmptyOperatorUnmodified() {
+        final var operator = SessionExtraDataOperator.empty();
+        final var sessionSummary = SessionSummary.builder()
+                .sessionId("s1")
+                .title("Test Session")
+                .summary("Test Summary")
+                .updatedAt(System.currentTimeMillis())
+                .build();
+
+        final var result = operator.apply(sessionSummary);
+
+        assertEquals(sessionSummary.getSessionId(), result.getSessionId());
+        assertEquals(sessionSummary.getExtra(), result.getExtra());
+        assertTrue(result.getExtra().isEmpty());
+    }
+
+    @Test
+    void testFixedOperatorComplexData() {
+        final var nestedMap = Map.of("nested", "data");
+        final var extraData = Map.<String, Object>of(
+                                                     "stringValue",
+                                                     "text",
+                                                     "numberValue",
+                                                     123L,
+                                                     "booleanValue",
+                                                     false,
+                                                     "nestedData",
+                                                     nestedMap
+        );
+        final var operator = SessionExtraDataOperator.fixed(extraData);
+        final var sessionSummary = SessionSummary.builder()
+                .sessionId("s1")
+                .title("Test")
+                .summary("Summary")
+                .updatedAt(System.currentTimeMillis())
+                .build();
+
+        final var result = operator.apply(sessionSummary);
+
+        assertEquals(4, result.getExtra().size());
+        assertEquals("text", result.getExtra().get("stringValue"));
+        assertEquals(123L, result.getExtra().get("numberValue"));
+        assertEquals(false, result.getExtra().get("booleanValue"));
+        assertSame(nestedMap, result.getExtra().get("nestedData"));
+    }
+
+    @Test
+    void testFixedOperatorEmptyMap() {
+        final var operator = SessionExtraDataOperator.fixed(Map.of());
+        final var sessionSummary = SessionSummary.builder()
+                .sessionId("s1")
+                .title("Test Session")
+                .summary("Test Summary")
+                .updatedAt(System.currentTimeMillis())
+                .build();
+
+        final var result = operator.apply(sessionSummary);
+
+        assertTrue(result.getExtra().isEmpty());
+    }
+
+    @Test
+    void testFixedOperatorInjectsData() {
+        final var extraData = Map.<String, Object>of("key1", "value1", "key2", 42, "key3", true);
+        final var operator = SessionExtraDataOperator.fixed(extraData);
+        final var sessionSummary = SessionSummary.builder()
+                .sessionId("s1")
+                .title("Test Session")
+                .summary("Test Summary")
+                .updatedAt(System.currentTimeMillis())
+                .build();
+
+        final var result = operator.apply(sessionSummary);
+
+        assertEquals(sessionSummary.getSessionId(), result.getSessionId());
+        assertNotNull(result.getExtra());
+        assertEquals(3, result.getExtra().size());
+        assertEquals("value1", result.getExtra().get("key1"));
+        assertEquals(42, result.getExtra().get("key2"));
+        assertEquals(true, result.getExtra().get("key3"));
+    }
+
+    @Test
+    void testFixedOperatorPreservesMetadata() {
+        final var extraData = Map.<String, Object>of("customKey", "customValue");
+        final var operator = SessionExtraDataOperator.fixed(extraData);
+        final var sessionId = "session-123";
+        final var title = "Important Session";
+        final var summary = "Session summary text";
+        final var updatedAt = 1623456789L;
+        final var keywords = List.of("topic1", "topic2");
+        final var lastMsgId = "msg-999";
+        final var raw = "{}";
+
+        final var sessionSummary = SessionSummary.builder()
+                .sessionId(sessionId)
+                .title(title)
+                .summary(summary)
+                .keywords(keywords)
+                .lastSummarizedMessageId(lastMsgId)
+                .raw(raw)
+                .updatedAt(updatedAt)
+                .build();
+
+        final var result = operator.apply(sessionSummary);
+
+        assertEquals(sessionId, result.getSessionId());
+        assertEquals(title, result.getTitle());
+        assertEquals(summary, result.getSummary());
+        assertEquals(keywords, result.getKeywords());
+        assertEquals(lastMsgId, result.getLastSummarizedMessageId());
+        assertEquals(raw, result.getRaw());
+        assertEquals(updatedAt, result.getUpdatedAt());
+        assertEquals(extraData, result.getExtra());
+    }
+
+    @Test
+    void testOperatorChaining() {
+        final var operator1 = SessionExtraDataOperator.fixed(Map.of("first", "data"));
+        final var operator2 = SessionExtraDataOperator.fixed(Map.of("second", "data"));
+
+        final var sessionSummary = SessionSummary.builder()
+                .sessionId("s1")
+                .title("Test")
+                .summary("Summary")
+                .updatedAt(System.currentTimeMillis())
+                .build();
+
+        final var result1 = operator1.apply(sessionSummary);
+        final var result2 = operator2.apply(result1);
+
+        assertEquals("data", result2.getExtra().get("second"));
+        assertFalse(result2.getExtra().containsKey("first"),
+                    "operator2 should replace, not merge, the extra data set by operator1");
+    }
+
+}

--- a/sentinel-ai-session/src/test/java/com/phonepe/sentinelai/session/SessionStoreTest.java
+++ b/sentinel-ai-session/src/test/java/com/phonepe/sentinelai/session/SessionStoreTest.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright (c) 2025 Original Author(s), PhonePe India Pvt. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.phonepe.sentinelai.session;
+
+
+import org.junit.jupiter.api.Test;
+
+import com.phonepe.sentinelai.core.agentmessages.AgentMessage;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SessionStoreTest {
+
+    private static class TestSessionStore extends SessionStore {
+        private final Map<String, SessionSummary> store = new ConcurrentHashMap<>();
+
+        TestSessionStore(SessionExtraDataOperator extraDataOperator) {
+            super(extraDataOperator);
+        }
+
+        @Override
+        public boolean deleteSession(String sessionId) {
+            return store.remove(sessionId) != null;
+        }
+
+        @Override
+        public BiScrollable<AgentMessage> readMessages(String sessionId,
+                                                       int count,
+                                                       boolean skipSystemPrompt,
+                                                       BiScrollable.DataPointer pointer,
+                                                       QueryDirection queryDirection) {
+            return null;
+        }
+
+        @Override
+        public void saveMessages(String sessionId,
+                                 String runId,
+                                 List<AgentMessage> messages) {
+        }
+
+        @Override
+        public Optional<SessionSummary> session(String sessionId) {
+            return Optional.ofNullable(store.get(sessionId));
+        }
+
+        @Override
+        public BiScrollable<SessionSummary> sessions(int count,
+                                                     String pointer,
+                                                     QueryDirection queryDirection) {
+            return null;
+        }
+
+        @Override
+        protected Optional<SessionSummary> saveSessionImpl(SessionSummary sessionSummary) {
+            store.put(sessionSummary.getSessionId(), sessionSummary);
+            return session(sessionSummary.getSessionId());
+        }
+    }
+
+    @Test
+    void testNoExtraDataOperator() {
+        final var store = new TestSessionStore(null);
+
+        final var sessionSummary = SessionSummary.builder()
+                .sessionId("s1")
+                .title("Test")
+                .summary("Summary")
+                .updatedAt(System.currentTimeMillis())
+                .build();
+
+        final var result = store.saveSession(sessionSummary);
+
+        assertTrue(result.isPresent());
+        assertTrue(result.get().getExtra().isEmpty());
+    }
+
+
+    @Test
+    void testSaveSessionAppliesExtraData() {
+        final var extraData = Map.<String, Object>of("testKey", "testValue");
+        final var operator = SessionExtraDataOperator.fixed(extraData);
+        final var store = new TestSessionStore(operator);
+
+        final var sessionSummary = SessionSummary.builder()
+                .sessionId("s1")
+                .title("Test")
+                .summary("Summary")
+                .updatedAt(System.currentTimeMillis())
+                .build();
+
+        final var result = store.saveSession(sessionSummary);
+
+        assertTrue(result.isPresent());
+        final var saved = result.get();
+        assertEquals("s1", saved.getSessionId());
+        assertEquals(extraData, saved.getExtra());
+        assertEquals("testValue", saved.getExtra().get("testKey"));
+    }
+
+    @Test
+    void testSaveSessionCustomOperator() {
+        final var operator = new SessionExtraDataOperator() {
+            @Override
+            protected Optional<Map<String, Object>> operate(SessionSummary sessionSummary) {
+                return Optional.of(Map.of("sessionId", sessionSummary.getSessionId()));
+            }
+        };
+        final var store = new TestSessionStore(operator);
+
+        final var sessionSummary = SessionSummary.builder()
+                .sessionId("dynamic-id-123")
+                .title("Test")
+                .summary("Summary")
+                .updatedAt(System.currentTimeMillis())
+                .build();
+
+        final var result = store.saveSession(sessionSummary);
+
+        assertTrue(result.isPresent());
+        final var saved = result.get();
+        assertEquals("dynamic-id-123", saved.getExtra().get("sessionId"));
+    }
+
+    @Test
+    void testSaveSessionEmptyOperator() {
+        final var store = new TestSessionStore(SessionExtraDataOperator.empty());
+
+        final var sessionSummary = SessionSummary.builder()
+                .sessionId("s1")
+                .title("Test")
+                .summary("Summary")
+                .updatedAt(System.currentTimeMillis())
+                .build();
+
+        final var result = store.saveSession(sessionSummary);
+
+        assertTrue(result.isPresent());
+        assertTrue(result.get().getExtra().isEmpty());
+    }
+
+    @Test
+    void testSaveSessionMultipleExtraEntries() {
+        final var extraData = Map.<String, Object>of(
+                                                     "key1",
+                                                     "value1",
+                                                     "key2",
+                                                     42,
+                                                     "key3",
+                                                     true,
+                                                     "key4",
+                                                     List.of("a", "b", "c")
+        );
+        final var operator = SessionExtraDataOperator.fixed(extraData);
+        final var store = new TestSessionStore(operator);
+
+        final var sessionSummary = SessionSummary.builder()
+                .sessionId("s1")
+                .title("Test")
+                .summary("Summary")
+                .updatedAt(System.currentTimeMillis())
+                .build();
+
+        final var result = store.saveSession(sessionSummary);
+
+        assertTrue(result.isPresent());
+        final var saved = result.get();
+        assertEquals(4, saved.getExtra().size());
+        assertEquals("value1", saved.getExtra().get("key1"));
+        assertEquals(42, saved.getExtra().get("key2"));
+        assertEquals(true, saved.getExtra().get("key3"));
+        assertEquals(List.of("a", "b", "c"), saved.getExtra().get("key4"));
+    }
+
+    @Test
+    void testSaveSessionPreservesMetadata() {
+        final var extraData = Map.<String, Object>of("extra", "data");
+        final var operator = SessionExtraDataOperator.fixed(extraData);
+        final var store = new TestSessionStore(operator);
+
+        final var sessionId = "test-session-123";
+        final var title = "Important Session";
+        final var summary = "Session conversation summary";
+        final var keywords = List.of("topic1", "topic2", "topic3");
+        final var lastMsgId = "msg-999";
+        final var raw = "{\"extracted\": \"data\"}";
+        final var updatedAt = 1623456789L;
+
+        final var sessionSummary = SessionSummary.builder()
+                .sessionId(sessionId)
+                .title(title)
+                .summary(summary)
+                .keywords(keywords)
+                .lastSummarizedMessageId(lastMsgId)
+                .raw(raw)
+                .updatedAt(updatedAt)
+                .build();
+
+        final var result = store.saveSession(sessionSummary);
+
+        assertTrue(result.isPresent());
+        final var saved = result.get();
+        assertEquals(sessionId, saved.getSessionId());
+        assertEquals(title, saved.getTitle());
+        assertEquals(summary, saved.getSummary());
+        assertEquals(keywords, saved.getKeywords());
+        assertEquals(lastMsgId, saved.getLastSummarizedMessageId());
+        assertEquals(raw, saved.getRaw());
+        assertEquals(updatedAt, saved.getUpdatedAt());
+        assertEquals(extraData, saved.getExtra());
+    }
+
+}

--- a/sentinel-ai-session/src/test/java/com/phonepe/sentinelai/session/SessionStoreTest.java
+++ b/sentinel-ai-session/src/test/java/com/phonepe/sentinelai/session/SessionStoreTest.java
@@ -56,6 +56,7 @@ class SessionStoreTest {
         public void saveMessages(String sessionId,
                                  String runId,
                                  List<AgentMessage> messages) {
+            // Nothing to do here
         }
 
         @Override

--- a/sentinel-ai-session/src/test/java/com/phonepe/sentinelai/session/SessionSummaryTest.java
+++ b/sentinel-ai-session/src/test/java/com/phonepe/sentinelai/session/SessionSummaryTest.java
@@ -19,10 +19,91 @@ package com.phonepe.sentinelai.session;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class SessionSummaryTest {
+
+    @Test
+    void testExtraData() {
+        final var extraData = Map.<String, Object>of(
+                                                     "key1",
+                                                     "value1",
+                                                     "key2",
+                                                     42,
+                                                     "key3",
+                                                     true);
+        final var sessionSummary = SessionSummary.builder()
+                .sessionId("s1")
+                .title("Title")
+                .summary("Summary")
+                .extra(extraData)
+                .updatedAt(System.currentTimeMillis())
+                .build();
+
+        assertEquals(extraData, sessionSummary.getExtra());
+        assertEquals(3, sessionSummary.getExtra().size());
+        assertEquals("value1", sessionSummary.getExtra().get("key1"));
+        assertEquals(42, sessionSummary.getExtra().get("key2"));
+        assertEquals(true, sessionSummary.getExtra().get("key3"));
+    }
+
+    @Test
+    void testExtraFieldDefaultsToEmptyMap() {
+        final var sessionSummary = SessionSummary.builder()
+                .sessionId("s1")
+                .title("Title")
+                .summary("Summary")
+                .updatedAt(System.currentTimeMillis())
+                .build();
+
+        assertNotNull(sessionSummary.getExtra());
+        assertTrue(sessionSummary.getExtra().isEmpty());
+    }
+
+    @Test
+    void testExtraMethodModifiesExtra() {
+        final var originalSummary = SessionSummary.builder()
+                .sessionId("s1")
+                .title("Title")
+                .summary("Summary")
+                .updatedAt(System.currentTimeMillis())
+                .build();
+
+        final var newExtra = Map.<String, Object>of("newKey", "newValue");
+        final var modifiedSummary = originalSummary.withExtra(newExtra);
+
+        assertTrue(originalSummary.getExtra().isEmpty());
+        assertEquals(newExtra, modifiedSummary.getExtra());
+        assertEquals("newValue", modifiedSummary.getExtra().get("newKey"));
+    }
+
+    @Test
+    void testExtraPreservesOtherFields() {
+        final var sessionId = "s1";
+        final var title = "Title";
+        final var summary = "Summary";
+        long updatedAt = System.currentTimeMillis();
+
+        final var originalSummary = SessionSummary.builder()
+                .sessionId(sessionId)
+                .title(title)
+                .summary(summary)
+                .updatedAt(updatedAt)
+                .build();
+
+        final var newExtra = Map.<String, Object>of("key", "value");
+        final var modifiedSummary = originalSummary.withExtra(newExtra);
+
+        assertEquals(sessionId, modifiedSummary.getSessionId());
+        assertEquals(title, modifiedSummary.getTitle());
+        assertEquals(summary, modifiedSummary.getSummary());
+        assertEquals(updatedAt, modifiedSummary.getUpdatedAt());
+        assertEquals(newExtra, modifiedSummary.getExtra());
+    }
 
     @Test
     void testSessionSummaryBuilderAndGetters() {
@@ -51,5 +132,22 @@ class SessionSummaryTest {
         assertEquals(lastMsgId, sessionSummary.getLastSummarizedMessageId());
         assertEquals(raw, sessionSummary.getRaw());
         assertEquals(updatedAt, sessionSummary.getUpdatedAt());
+    }
+
+    @Test
+    void testUpdatedAtPreservesExtraData() {
+        final var extraData = Map.<String, Object>of("key", "value");
+        final var originalSummary = SessionSummary.builder()
+                .sessionId("s1")
+                .title("Title")
+                .summary("Summary")
+                .extra(extraData)
+                .updatedAt(100L)
+                .build();
+
+        final var modifiedSummary = originalSummary.withUpdatedAt(200L);
+
+        assertEquals(extraData, modifiedSummary.getExtra());
+        assertEquals(200L, modifiedSummary.getUpdatedAt());
     }
 }

--- a/sentinel-ai-storage-es/src/main/java/com/phonepe/sentinelai/storage/session/ESSessionDocument.java
+++ b/sentinel-ai-storage-es/src/main/java/com/phonepe/sentinelai/storage/session/ESSessionDocument.java
@@ -40,6 +40,8 @@ public class ESSessionDocument {
 
     String lastSummarizedMessageId;
 
+    String extraJson;
+
     long updatedAtMicro;
 
     LocalDateTime createdAt;

--- a/sentinel-ai-storage-es/src/main/java/com/phonepe/sentinelai/storage/session/ESSessionStore.java
+++ b/sentinel-ai-storage-es/src/main/java/com/phonepe/sentinelai/storage/session/ESSessionStore.java
@@ -16,6 +16,7 @@
 
 package com.phonepe.sentinelai.storage.session;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Strings;
 
@@ -25,6 +26,7 @@ import com.phonepe.sentinelai.core.utils.AgentUtils;
 import com.phonepe.sentinelai.core.utils.JsonUtils;
 import com.phonepe.sentinelai.session.BiScrollable;
 import com.phonepe.sentinelai.session.QueryDirection;
+import com.phonepe.sentinelai.session.SessionExtraDataOperator;
 import com.phonepe.sentinelai.session.SessionStore;
 import com.phonepe.sentinelai.session.SessionSummary;
 import com.phonepe.sentinelai.storage.ESClient;
@@ -51,10 +53,13 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.function.UnaryOperator;
+
+import javax.annotation.Nullable;
 
 import static co.elastic.clients.elasticsearch._types.Refresh.True;
 
@@ -62,7 +67,7 @@ import static co.elastic.clients.elasticsearch._types.Refresh.True;
  * Storage for session data
  */
 @Slf4j
-public class ESSessionStore implements SessionStore {
+public class ESSessionStore extends SessionStore {
     private static final String SESSIONS_INDEX = "agent-sessions";
 
     private static final String SESSION_AUTO_UPDATE_PIPELINE = "update_session_summary_created_updated";
@@ -80,7 +85,9 @@ public class ESSessionStore implements SessionStore {
                           String indexPrefix,
                           IndexSettings sessionIndexSettings,
                           IndexSettings messageIndexSettings,
-                          ObjectMapper mapper) {
+                          ObjectMapper mapper,
+                          @Nullable SessionExtraDataOperator extraDataOperator) {
+        super(extraDataOperator);
         this.client = client;
         this.indexPrefix = indexPrefix;
         this.mapper = Objects.requireNonNullElseGet(mapper,
@@ -232,24 +239,6 @@ public class ESSessionStore implements SessionStore {
         log.debug("Bulk message indexing response: {}", response);
     }
 
-
-    @Override
-    @SneakyThrows
-    public Optional<SessionSummary> saveSession(SessionSummary sessionSummary) {
-        final var stored = toStoredSession(sessionSummary);
-        final var indexName = sessionIndexName();
-        final var result = client.getElasticsearchClient()
-                .update(u -> u.index(indexName)
-                        .id(stored.getSessionId())
-                        .doc(stored)
-                        .docAsUpsert(true)
-                        .refresh(True), ESSessionDocument.class)
-                .result();
-
-        log.debug("Result of indexing: {}", result);
-        return session(sessionSummary.getSessionId());
-    }
-
     @Override
     @SneakyThrows
     public Optional<SessionSummary> session(String sessionId) {
@@ -308,6 +297,23 @@ public class ESSessionStore implements SessionStore {
         final var newer = queryDirection == QueryDirection.NEWER ? newestResultPtr : updatedNewerForOldQuery;
 
         return new BiScrollable<>(summaries, new BiScrollable.DataPointer(older, newer));
+    }
+
+    @Override
+    @SneakyThrows
+    protected Optional<SessionSummary> saveSessionImpl(SessionSummary sessionSummary) {
+        final var stored = toStoredSession(sessionSummary);
+        final var indexName = sessionIndexName();
+        final var result = client.getElasticsearchClient()
+                .update(u -> u.index(indexName)
+                        .id(stored.getSessionId())
+                        .doc(stored)
+                        .docAsUpsert(true)
+                        .refresh(True), ESSessionDocument.class)
+                .result();
+
+        log.debug("Result of indexing: {}", result);
+        return session(sessionSummary.getSessionId());
     }
 
     record MessageScrollPointer(
@@ -433,6 +439,9 @@ public class ESSessionStore implements SessionStore {
                             .properties(ESSessionDocument.Fields.lastSummarizedMessageId,
                                         p -> p.text(t -> t.store(false)
                                                 .index(false)))
+                            .properties(ESSessionDocument.Fields.extraJson,
+                                        p -> p.text(t -> t.store(false)
+                                                .index(false)))
                             .properties(ESSessionDocument.Fields.updatedAtMicro,
                                         p -> p.long_(t -> t))
                             .properties(ESSessionDocument.Fields.createdAt,
@@ -510,6 +519,7 @@ public class ESSessionStore implements SessionStore {
                 .raw(mapper.writeValueAsString(sessionSummary.getRaw()))
                 .lastSummarizedMessageId(sessionSummary
                         .getLastSummarizedMessageId())
+                .extraJson(mapper.writeValueAsString(sessionSummary.getExtra()))
                 .updatedAtMicro(sessionSummary.getUpdatedAt())
                 .build();
     }
@@ -520,6 +530,7 @@ public class ESSessionStore implements SessionStore {
         return mapper.readValue(document.getContent(), AgentMessage.class);
     }
 
+    @SneakyThrows
     private SessionSummary toWireSession(ESSessionDocument document) {
         return SessionSummary.builder()
                 .sessionId(document.getSessionId())
@@ -527,8 +538,18 @@ public class ESSessionStore implements SessionStore {
                 .keywords(document.getTopics())
                 .raw(document.getRaw())
                 .lastSummarizedMessageId(document.getLastSummarizedMessageId())
+                .extra(parseExtra(document.getExtraJson()))
                 .updatedAt(document.getUpdatedAtMicro())
                 .build();
+    }
+
+    @SneakyThrows
+    private Map<String, Object> parseExtra(String extraJson) {
+        if (Strings.isNullOrEmpty(extraJson)) {
+            return Map.of();
+        }
+        return mapper.readValue(extraJson, new TypeReference<Map<String, Object>>() {
+        });
     }
 
 }

--- a/sentinel-ai-storage-es/src/test/java/com/phonepe/sentinelai/storage/AgentIntegrationTest.java
+++ b/sentinel-ai-storage-es/src/test/java/com/phonepe/sentinelai/storage/AgentIntegrationTest.java
@@ -49,6 +49,7 @@ import com.phonepe.sentinelai.embedding.HuggingfaceEmbeddingModel;
 import com.phonepe.sentinelai.models.SimpleOpenAIModel;
 import com.phonepe.sentinelai.session.AgentSessionExtension;
 import com.phonepe.sentinelai.session.AgentSessionExtensionSetup;
+import com.phonepe.sentinelai.session.SessionExtraDataOperator;
 import com.phonepe.sentinelai.session.SessionSummary;
 import com.phonepe.sentinelai.storage.memory.ESAgentMemoryStorage;
 import com.phonepe.sentinelai.storage.session.ESSessionStore;
@@ -66,6 +67,7 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static com.phonepe.sentinelai.core.utils.TestUtils.ensureOutputGenerated;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -193,7 +195,8 @@ class AgentIntegrationTest extends ESIntegrationTestBase {
                                                       indexPrefix(this),
                                                       IndexSettings.DEFAULT,
                                                       IndexSettings.DEFAULT,
-                                                      objectMapper);
+                                                      objectMapper,
+                                                      SessionExtraDataOperator.fixed(Map.of("testKey", "testValue")));
         final var agentSessionExtension = AgentSessionExtension
                 .<UserInput, OutputObject, SimpleAgent>builder()
                 .sessionStore(sessionStorage)
@@ -235,6 +238,13 @@ class AgentIntegrationTest extends ESIntegrationTestBase {
         Awaitility.await()
                 .atMost(Duration.ofSeconds(30))
                 .until(() -> sessionStorage.session("s1").isPresent());
+        assertAll(() -> {
+            final var session = sessionStorage.session("s1");
+            assertTrue(session.isPresent());
+            final var sessionSummary = session.get();
+            log.info("Session summary: {}", sessionSummary);
+            assertTrue(sessionSummary.getExtra().containsKey("testKey"));
+        });
         final var updatedTime = new AtomicLong(sessionStorage.session("s1")
                 .get()
                 .getUpdatedAt());

--- a/sentinel-ai-storage-es/src/test/java/com/phonepe/sentinelai/storage/session/ESSessionStoreTest.java
+++ b/sentinel-ai-storage-es/src/test/java/com/phonepe/sentinelai/storage/session/ESSessionStoreTest.java
@@ -34,6 +34,7 @@ import com.phonepe.sentinelai.core.utils.AgentUtils;
 import com.phonepe.sentinelai.core.utils.TestUtils;
 import com.phonepe.sentinelai.session.BiScrollable;
 import com.phonepe.sentinelai.session.QueryDirection;
+import com.phonepe.sentinelai.session.SessionExtraDataOperator;
 import com.phonepe.sentinelai.session.SessionSummary;
 import com.phonepe.sentinelai.storage.ESClient;
 import com.phonepe.sentinelai.storage.ESIntegrationTestBase;
@@ -43,6 +44,7 @@ import lombok.SneakyThrows;
 
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -54,6 +56,132 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ESSessionStoreTest extends ESIntegrationTestBase {
+
+    @Test
+    @SneakyThrows
+    void sessionStorage() {
+        try (final var client = ESClient.builder()
+                .serverUrl(ELASTICSEARCH_CONTAINER.getHttpHostAddress())
+                .apiKey(TestUtils.getTestProperty("ES_API_KEY", "test"))
+                .build()) {
+
+            final var sessionStore = ESSessionStore.builder()
+                    .client(client)
+                    .indexPrefix("test")
+                    .sessionIndexSettings(IndexSettings.DEFAULT)
+                    .messageIndexSettings(IndexSettings.DEFAULT)
+                    .build();
+
+
+            final var sessionId = "test-session";
+            final var sessionSummary = SessionSummary.builder()
+                    .sessionId(sessionId)
+                    .summary("Test Summary")
+                    .keywords(List.of("topic1", "topic2"))
+                    .updatedAt(AgentUtils.epochMicro())
+                    .build();
+
+            final var savedSession = sessionStore.saveSessionImpl(sessionSummary);
+            assertTrue(savedSession.isPresent());
+            assertEquals(sessionId, savedSession.get().getSessionId());
+
+            final var retrievedSession = sessionStore.session(sessionId);
+            assertTrue(retrievedSession.isPresent());
+            assertEquals("Test Summary", retrievedSession.get().getSummary());
+
+            final var sessions = sessionStore.sessions(10,
+                                                       null,
+                                                       QueryDirection.OLDER);
+            assertFalse(sessions.getItems().isEmpty());
+            assertEquals(1, sessions.getItems().size());
+            assertEquals(sessionId, sessions.getItems().get(0).getSessionId());
+
+            final var updatedSessionSummary = SessionSummary.builder()
+                    .sessionId(sessionId)
+                    .summary("Updated Summary")
+                    .keywords(List.of("topic1", "topic2"))
+                    .updatedAt(AgentUtils.epochMicro())
+                    .build();
+            final var updatedSession = sessionStore.saveSessionImpl(
+                                                                    updatedSessionSummary);
+            assertTrue(updatedSession.isPresent());
+            assertEquals("Updated Summary", updatedSession.get().getSummary());
+            assertTrue(sessionStore.deleteSession(sessionId));
+            assertFalse(sessionStore.session(sessionId).isPresent());
+
+            final var savedIds = IntStream.rangeClosed(1, 25)
+                    .mapToObj(i -> sessionStore.saveSessionImpl(SessionSummary
+                            .builder()
+                            .sessionId("S-" + i)
+                            .summary("Summary " + i)
+                            .keywords(List.of())
+                            .updatedAt(AgentUtils.epochMicro())
+                            .build())
+                            .map(SessionSummary::getSessionId)
+                            .orElse(null))
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.toUnmodifiableSet());
+            var nextPointer = "";
+            final var retrieved = new HashSet<String>();
+            do {
+                final var response = sessionStore.sessions(10,
+                                                           nextPointer,
+                                                           QueryDirection.OLDER);
+                assertNotNull(response.getItems());
+                response.getItems()
+                        .forEach(s -> retrieved.add(s.getSessionId()));
+                assertNotNull(response.getPointer());
+                nextPointer = response.getPointer().getOlder();
+            } while (!retrieved.containsAll(savedIds));
+            assertEquals(savedIds.size(), retrieved.size(), () -> {
+                final var savedSize = savedIds.size();
+                final var retrievedSize = retrieved.size();
+                final var diff = savedSize > retrievedSize ? Sets.difference(
+                                                                             savedIds,
+                                                                             retrieved)
+                        : Sets.difference(retrieved, savedIds);
+                return "Expected to retrieve %d sessions, but got %d. Extra: %s"
+                        .formatted(savedSize,
+                                   retrievedSize,
+                                   String.join(",", diff));
+            });
+            assertTrue(retrieved.containsAll(savedIds),
+                       () -> "Retrieved sessions do not contain all saved sessions. Missing: " + String
+                               .join(",",
+                                     Sets.difference(savedIds, retrieved)));
+        }
+    }
+
+    @Test
+    @SneakyThrows
+    void testBuilderWithExtraDataOperator() {
+        try (final var client = ESClient.builder()
+                .serverUrl(ELASTICSEARCH_CONTAINER.getHttpHostAddress())
+                .apiKey(TestUtils.getTestProperty("ES_API_KEY", "test"))
+                .build()) {
+
+            final var operator = SessionExtraDataOperator.fixed(Map.of("builder", "test"));
+            final var sessionStore = ESSessionStore.builder()
+                    .client(client)
+                    .indexPrefix("test-builder")
+                    .sessionIndexSettings(IndexSettings.DEFAULT)
+                    .messageIndexSettings(IndexSettings.DEFAULT)
+                    .extraDataOperator(operator)
+                    .build();
+
+            assertNotNull(sessionStore);
+            final var sessionId = "test-builder-session";
+            final var sessionSummary = SessionSummary.builder()
+                    .sessionId(sessionId)
+                    .summary("Builder Test")
+                    .updatedAt(AgentUtils.epochMicro())
+                    .build();
+
+            final var savedSession = sessionStore.saveSession(sessionSummary);
+            assertTrue(savedSession.isPresent());
+            assertEquals(Map.of("builder", "test"), savedSession.get().getExtra());
+        }
+    }
 
     @Test
     @SneakyThrows
@@ -123,7 +251,7 @@ class ESSessionStoreTest extends ESIntegrationTestBase {
                     .map(AgentMessage::getMessageId)
                     .collect(Collectors.toUnmodifiableSet());
 
-            sessionStore.saveSessionImpl(SessionSummary.builder()
+            sessionStore.saveSession(SessionSummary.builder()
                     .sessionId(sessionId)
                     .updatedAt(AgentUtils.epochMicro())
                     .build());
@@ -226,96 +354,103 @@ class ESSessionStoreTest extends ESIntegrationTestBase {
 
     @Test
     @SneakyThrows
-    void testSessionStorage() {
+    void testSessionStorageWithComplexExtraData() {
         try (final var client = ESClient.builder()
                 .serverUrl(ELASTICSEARCH_CONTAINER.getHttpHostAddress())
                 .apiKey(TestUtils.getTestProperty("ES_API_KEY", "test"))
                 .build()) {
 
+            final var nestedMap = Map.of("nested", "value");
+            final var extraData = Map.<String, Object>of(
+                                                         "stringValue",
+                                                         "text",
+                                                         "numberValue",
+                                                         42L,
+                                                         "booleanValue",
+                                                         true,
+                                                         "listValue",
+                                                         List.of("a",
+                                                                 "b",
+                                                                 "c"),
+                                                         "nested",
+                                                         nestedMap
+            );
+            final var operator = SessionExtraDataOperator.fixed(extraData);
+
             final var sessionStore = ESSessionStore.builder()
                     .client(client)
-                    .indexPrefix("test")
+                    .indexPrefix("test-complex")
                     .sessionIndexSettings(IndexSettings.DEFAULT)
                     .messageIndexSettings(IndexSettings.DEFAULT)
+                    .extraDataOperator(operator)
                     .build();
 
-
-            final var sessionId = "test-session";
+            final var sessionId = "session-complex";
             final var sessionSummary = SessionSummary.builder()
                     .sessionId(sessionId)
+                    .summary("Complex Extra Data Test")
+                    .updatedAt(AgentUtils.epochMicro())
+                    .build();
+
+            final var savedSession = sessionStore.saveSession(sessionSummary);
+            assertTrue(savedSession.isPresent());
+            assertEquals(5, savedSession.get().getExtra().size());
+            assertEquals("text", savedSession.get().getExtra().get("stringValue"));
+            assertEquals(((Number) savedSession.get().getExtra().get("numberValue")).longValue(), 42L);
+            assertEquals(true, savedSession.get().getExtra().get("booleanValue"));
+            assertEquals(List.of("a", "b", "c"), savedSession.get().getExtra().get("listValue"));
+
+            final var retrievedSession = sessionStore.session(sessionId);
+            assertTrue(retrievedSession.isPresent());
+            assertEquals(5, retrievedSession.get().getExtra().size());
+        }
+    }
+
+    @Test
+    @SneakyThrows
+    void testSessionStorageWithExtraData() {
+        try (final var client = ESClient.builder()
+                .serverUrl(ELASTICSEARCH_CONTAINER.getHttpHostAddress())
+                .apiKey(TestUtils.getTestProperty("ES_API_KEY", "test"))
+                .build()) {
+
+            final var extraData = Map.<String, Object>of(
+                                                         "source",
+                                                         "elasticsearch",
+                                                         "version",
+                                                         "1.0",
+                                                         "priority",
+                                                         10
+            );
+            final var operator = SessionExtraDataOperator.fixed(extraData);
+
+            final var sessionStore = ESSessionStore.builder()
+                    .client(client)
+                    .indexPrefix("test-extra")
+                    .sessionIndexSettings(IndexSettings.DEFAULT)
+                    .messageIndexSettings(IndexSettings.DEFAULT)
+                    .extraDataOperator(operator)
+                    .build();
+
+            final var sessionId = "session-with-extra";
+            final var sessionSummary = SessionSummary.builder()
+                    .sessionId(sessionId)
+                    .title("Session with Extra Data")
                     .summary("Test Summary")
                     .keywords(List.of("topic1", "topic2"))
                     .updatedAt(AgentUtils.epochMicro())
                     .build();
 
-            final var savedSession = sessionStore.saveSessionImpl(sessionSummary);
+            final var savedSession = sessionStore.saveSession(sessionSummary);
             assertTrue(savedSession.isPresent());
-            assertEquals(sessionId, savedSession.get().getSessionId());
+            assertEquals(extraData, savedSession.get().getExtra());
 
             final var retrievedSession = sessionStore.session(sessionId);
             assertTrue(retrievedSession.isPresent());
-            assertEquals("Test Summary", retrievedSession.get().getSummary());
-
-            final var sessions = sessionStore.sessions(10,
-                                                       null,
-                                                       QueryDirection.OLDER);
-            assertFalse(sessions.getItems().isEmpty());
-            assertEquals(1, sessions.getItems().size());
-            assertEquals(sessionId, sessions.getItems().get(0).getSessionId());
-
-            final var updatedSessionSummary = SessionSummary.builder()
-                    .sessionId(sessionId)
-                    .summary("Updated Summary")
-                    .keywords(List.of("topic1", "topic2"))
-                    .updatedAt(AgentUtils.epochMicro())
-                    .build();
-            final var updatedSession = sessionStore.saveSessionImpl(
-                                                                    updatedSessionSummary);
-            assertTrue(updatedSession.isPresent());
-            assertEquals("Updated Summary", updatedSession.get().getSummary());
-            assertTrue(sessionStore.deleteSession(sessionId));
-            assertFalse(sessionStore.session(sessionId).isPresent());
-
-            final var savedIds = IntStream.rangeClosed(1, 25)
-                    .mapToObj(i -> sessionStore.saveSessionImpl(SessionSummary
-                            .builder()
-                            .sessionId("S-" + i)
-                            .summary("Summary " + i)
-                            .keywords(List.of())
-                            .updatedAt(AgentUtils.epochMicro())
-                            .build())
-                            .map(SessionSummary::getSessionId)
-                            .orElse(null))
-                    .filter(Objects::nonNull)
-                    .collect(Collectors.toUnmodifiableSet());
-            var nextPointer = "";
-            final var retrieved = new HashSet<String>();
-            do {
-                final var response = sessionStore.sessions(10,
-                                                           nextPointer,
-                                                           QueryDirection.OLDER);
-                assertNotNull(response.getItems());
-                response.getItems()
-                        .forEach(s -> retrieved.add(s.getSessionId()));
-                assertNotNull(response.getPointer());
-                nextPointer = response.getPointer().getOlder();
-            } while (!retrieved.containsAll(savedIds));
-            assertEquals(savedIds.size(), retrieved.size(), () -> {
-                final var savedSize = savedIds.size();
-                final var retrievedSize = retrieved.size();
-                final var diff = savedSize > retrievedSize ? Sets.difference(
-                                                                             savedIds,
-                                                                             retrieved)
-                        : Sets.difference(retrieved, savedIds);
-                return "Expected to retrieve %d sessions, but got %d. Extra: %s"
-                        .formatted(savedSize,
-                                   retrievedSize,
-                                   String.join(",", diff));
-            });
-            assertTrue(retrieved.containsAll(savedIds),
-                       () -> "Retrieved sessions do not contain all saved sessions. Missing: " + String
-                               .join(",",
-                                     Sets.difference(savedIds, retrieved)));
+            assertEquals(extraData, retrievedSession.get().getExtra());
+            assertTrue(retrievedSession.get().getExtra().containsKey("source"));
+            assertTrue(retrievedSession.get().getExtra().containsKey("version"));
+            assertTrue(retrievedSession.get().getExtra().containsKey("priority"));
         }
     }
 }

--- a/sentinel-ai-storage-es/src/test/java/com/phonepe/sentinelai/storage/session/ESSessionStoreTest.java
+++ b/sentinel-ai-storage-es/src/test/java/com/phonepe/sentinelai/storage/session/ESSessionStoreTest.java
@@ -396,7 +396,7 @@ class ESSessionStoreTest extends ESIntegrationTestBase {
             assertTrue(savedSession.isPresent());
             assertEquals(5, savedSession.get().getExtra().size());
             assertEquals("text", savedSession.get().getExtra().get("stringValue"));
-            assertEquals(((Number) savedSession.get().getExtra().get("numberValue")).longValue(), 42L);
+            assertEquals(42L, ((Number) savedSession.get().getExtra().get("numberValue")).longValue());
             assertEquals(true, savedSession.get().getExtra().get("booleanValue"));
             assertEquals(List.of("a", "b", "c"), savedSession.get().getExtra().get("listValue"));
 

--- a/sentinel-ai-storage-es/src/test/java/com/phonepe/sentinelai/storage/session/ESSessionStoreTest.java
+++ b/sentinel-ai-storage-es/src/test/java/com/phonepe/sentinelai/storage/session/ESSessionStoreTest.java
@@ -123,7 +123,7 @@ class ESSessionStoreTest extends ESIntegrationTestBase {
                     .map(AgentMessage::getMessageId)
                     .collect(Collectors.toUnmodifiableSet());
 
-            sessionStore.saveSession(SessionSummary.builder()
+            sessionStore.saveSessionImpl(SessionSummary.builder()
                     .sessionId(sessionId)
                     .updatedAt(AgentUtils.epochMicro())
                     .build());
@@ -241,7 +241,6 @@ class ESSessionStoreTest extends ESIntegrationTestBase {
 
 
             final var sessionId = "test-session";
-            final var agentName = "test-agent";
             final var sessionSummary = SessionSummary.builder()
                     .sessionId(sessionId)
                     .summary("Test Summary")
@@ -249,7 +248,7 @@ class ESSessionStoreTest extends ESIntegrationTestBase {
                     .updatedAt(AgentUtils.epochMicro())
                     .build();
 
-            final var savedSession = sessionStore.saveSession(sessionSummary);
+            final var savedSession = sessionStore.saveSessionImpl(sessionSummary);
             assertTrue(savedSession.isPresent());
             assertEquals(sessionId, savedSession.get().getSessionId());
 
@@ -270,15 +269,15 @@ class ESSessionStoreTest extends ESIntegrationTestBase {
                     .keywords(List.of("topic1", "topic2"))
                     .updatedAt(AgentUtils.epochMicro())
                     .build();
-            final var updatedSession = sessionStore.saveSession(
-                                                                updatedSessionSummary);
+            final var updatedSession = sessionStore.saveSessionImpl(
+                                                                    updatedSessionSummary);
             assertTrue(updatedSession.isPresent());
             assertEquals("Updated Summary", updatedSession.get().getSummary());
             assertTrue(sessionStore.deleteSession(sessionId));
             assertFalse(sessionStore.session(sessionId).isPresent());
 
             final var savedIds = IntStream.rangeClosed(1, 25)
-                    .mapToObj(i -> sessionStore.saveSession(SessionSummary
+                    .mapToObj(i -> sessionStore.saveSessionImpl(SessionSummary
                             .builder()
                             .sessionId("S-" + i)
                             .summary("Summary " + i)


### PR DESCRIPTION
## Summary

This PR introduces the ability to inject custom extra data into session summaries, making them richer and more extensible.

## Changes

### New Features
- **`SessionExtraDataOperator`**: A new abstract class implementing `UnaryOperator<SessionSummary>` that allows callers to inject arbitrary key-value extra data into a `SessionSummary`. Ships with:
  - `NoOp` — a no-op implementation (default, preserves existing behaviour)
  - `SessionExtraDataOperator.empty()` — factory for the no-op
  - `SessionExtraDataOperator.fixed(Map)` — factory for injecting a static map

### Modified
- **`SessionSummary`**: Added `extra` field and `withExtra()` method to carry the injected data
- **`SessionStore`**: Updated to thread the operator through the session store API
- **`FileSystemSessionStore`**: Wired up support for the new operator
- **`ESSessionStore` / `ESSessionDocument`**: Wired up support for the new operator

### Tests
- `SessionExtraDataOperatorTest` — comprehensive tests for the new operator
- `SessionStoreTest` — new tests for session store behaviour
- `SessionSummaryTest` — tests for the new `extra` field
- Extended `FileSystemSessionStoreTest`, `AgentSessionExtensionTest`, `MessageReadingUtilsTest`, `ESSessionStoreTest` and integration tests

### Docs
- Updated `docs/docs/messages-session.md` to document the new extra data injection capability

