### PR TITLE
Setting tool call arguments to {} if not sent

### DIFF
--- a/sentinel-ai-core/src/main/java/com/phonepe/sentinelai/core/agentmessages/responses/ToolCall.java
+++ b/sentinel-ai-core/src/main/java/com/phonepe/sentinelai/core/agentmessages/responses/ToolCall.java
@@ -16,6 +16,7 @@
 
 package com.phonepe.sentinelai.core.agentmessages.responses;
 
+import com.google.common.base.Strings;
 import com.phonepe.sentinelai.core.agentmessages.AgentMessageType;
 import com.phonepe.sentinelai.core.agentmessages.AgentResponse;
 import com.phonepe.sentinelai.core.agentmessages.AgentResponseVisitor;
@@ -34,6 +35,8 @@ import lombok.extern.jackson.Jacksonized;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class ToolCall extends AgentResponse {
+    public static final String EMPTY_ARGUMENTS = "{}";
+
     /**
      * Tool call id as received from LLM
      */
@@ -65,7 +68,7 @@ public class ToolCall extends AgentResponse {
               timestamp);
         this.toolCallId = toolCallId;
         this.toolName = toolName;
-        this.arguments = arguments;
+        this.arguments = Strings.isNullOrEmpty(arguments) ? EMPTY_ARGUMENTS : arguments;
     }
 
     public ToolCall(String sessionId,

--- a/sentinel-ai-core/src/main/java/com/phonepe/sentinelai/core/agentmessages/responses/ToolCall.java
+++ b/sentinel-ai-core/src/main/java/com/phonepe/sentinelai/core/agentmessages/responses/ToolCall.java
@@ -17,6 +17,7 @@
 package com.phonepe.sentinelai.core.agentmessages.responses;
 
 import com.google.common.base.Strings;
+
 import com.phonepe.sentinelai.core.agentmessages.AgentMessageType;
 import com.phonepe.sentinelai.core.agentmessages.AgentResponse;
 import com.phonepe.sentinelai.core.agentmessages.AgentResponseVisitor;

--- a/sentinel-ai-core/src/main/java/com/phonepe/sentinelai/core/events/ToolCalledAgentEvent.java
+++ b/sentinel-ai-core/src/main/java/com/phonepe/sentinelai/core/events/ToolCalledAgentEvent.java
@@ -42,7 +42,7 @@ public class ToolCalledAgentEvent extends AgentEvent {
                                 String userId,
                                 @NonNull String toolCallId,
                                 @NonNull String toolCallName,
-                                @NonNull String arguments) {
+                                String arguments) {
         super(EventType.TOOL_CALLED, agentName, runId, sessionId, userId);
         this.toolCallId = toolCallId;
         this.toolCallName = toolCallName;

--- a/sentinel-ai-core/src/test/java/com/phonepe/sentinelai/core/utils/ToolUtilsTest.java
+++ b/sentinel-ai-core/src/test/java/com/phonepe/sentinelai/core/utils/ToolUtilsTest.java
@@ -25,6 +25,7 @@ import com.phonepe.sentinelai.core.errors.ErrorType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ToolUtilsTest {
@@ -111,4 +112,26 @@ class ToolUtilsTest {
         assertTrue(result.getResponse().startsWith("Error running tool:"));
         assertTrue(result.getResponse().contains(errorMessage));
     }
+
+    @Test
+    void testToolCallWithtEmptyArguments() {
+        //This is aa trivial test to ensure that the ToolCall builder can handle
+        //null or empty arguments without throwing an exception and sets a default value
+        assertEquals(ToolCall.EMPTY_ARGUMENTS,
+                     ToolCall.builder()
+                             .sessionId(SESSION_ID)
+                             .runId(RUN_ID)
+                             .toolCallId("call-6")
+                             .toolName("tool")
+                             .build().getArguments());
+        assertEquals(ToolCall.EMPTY_ARGUMENTS,
+                     ToolCall.builder()
+                             .sessionId(SESSION_ID)
+                             .runId(RUN_ID)
+                             .toolCallId("call-6")
+                             .toolName("tool")
+                             .arguments("")
+                             .build().getArguments());
+    }
+
 }

--- a/sentinel-ai-core/src/test/java/com/phonepe/sentinelai/core/utils/ToolUtilsTest.java
+++ b/sentinel-ai-core/src/test/java/com/phonepe/sentinelai/core/utils/ToolUtilsTest.java
@@ -25,7 +25,6 @@ import com.phonepe.sentinelai.core.errors.ErrorType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ToolUtilsTest {


### PR DESCRIPTION
In case of streaming mode, sometimes the LLM doesn't send arguments for methods that don't have parameters.
This simple fix ensures that we initialize argument to empty json in that case
